### PR TITLE
[보안] javapns-jdk16이 물고오는 구버전 log4j 1.x 제외 (CVE-2019-17571 등)

### DIFF
--- a/device-api-web/pom.xml
+++ b/device-api-web/pom.xml
@@ -160,10 +160,18 @@
 		</dependency>
 
 		<!-- Apple APNS Push -->
+		<!-- CVE-2019-17571, CVE-2022-23302, CVE-2022-23305, CVE-2022-23307: javapns-jdk16이 물고오는
+		구버전 log4j 1.2.12 제외. log4j-over-slf4j가 동일 API를 대체 제공 -->
 		<dependency>
 			<groupId>com.github.fernandospr</groupId>
 			<artifactId>javapns-jdk16</artifactId>
 			<version>${javapns-jdk16.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<!-- FCM(Firebase Cloud Messaging) 구성 시작  -->
 		<dependency>


### PR DESCRIPTION
## 변경 사유

`device-api-web`의 Apple APNS Push 의존성 `com.github.fernandospr:javapns-jdk16:2.4.0`이 전이 의존성으로 EOL된 `log4j:log4j:1.2.12`를 끌어옵니다. 이 버전은 다음 CVE에 해당합니다.

- CVE-2019-17571 (SocketServer 역직렬화 RCE)
- CVE-2022-23302 (JMSSink RCE)
- CVE-2022-23305 (JDBCAppender SQL Injection)
- CVE-2022-23307 (Chainsaw 역직렬화)

## 변경 내용

`device-api-web/pom.xml`의 `javapns-jdk16` 의존성에 `log4j:log4j` exclusion을 추가했습니다. 애플리케이션 코드는 `org.apache.log4j` 패키지를 직접 참조하지 않고, 이미 클래스패스에 있는 `log4j-over-slf4j`가 동일 API를 대체 제공하므로 안전하게 제거 가능합니다.

## 테스트 방법 / 영향 범위

`mvn dependency:tree`로 `log4j:log4j`가 의존성 트리에서 완전히 제거됨을 확인했고, `mvn compile`이 정상 통과함을 확인했습니다. 런타임 로깅은 `log4j-over-slf4j`가 계속 담당하므로 동작 변화가 없습니다.

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] 테스트 통과 확인 (dependency:tree + compile)