### PR TITLE
[refactor] device-api-web VO 클래스 Lombok @Getter/@Setter 적용

### DIFF
--- a/device-api-web/src/main/java/egovframework/hyb/mbl/acl/service/AcceleratorAPIVO.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/acl/service/AcceleratorAPIVO.java
@@ -18,17 +18,21 @@ package egovframework.hyb.mbl.acl.service;
 import java.io.Serializable;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
 
-/**  
+/**
  * @Class Name : AcceleratorAPIVO.java
  * @Description : 통합 Accelerator API VO Class (Android/iOS 공통)
- * @Modification Information  
+ * @Modification Information
  * @
  * @ 수정일               수정자              수정내용
  * @ ----------   ---------   -------------------------------
  *   2025.10.28   통합개발팀          Android/iOS 패키지 통합
- * 
+ *
  */
+@Getter
+@Setter
 @Schema(description = "가속도계 API VO")
 public class AcceleratorAPIVO implements Serializable {
 
@@ -54,60 +58,4 @@ public class AcceleratorAPIVO implements Serializable {
 
     /** 사용여부 */
     private String useYn;
-
-    public int getSn() {
-        return sn;
-    }
-
-    public void setSn(int sn) {
-        this.sn = sn;
-    }
-
-    public String getUuid() {
-        return uuid;
-    }
-
-    public void setUuid(String uuid) {
-        this.uuid = uuid;
-    }
-
-    public String getXaxis() {
-        return xaxis;
-    }
-
-    public void setXaxis(String xaxis) {
-        this.xaxis = xaxis;
-    }
-
-    public String getYaxis() {
-        return yaxis;
-    }
-
-    public void setYaxis(String yaxis) {
-        this.yaxis = yaxis;
-    }
-
-    public String getZaxis() {
-        return zaxis;
-    }
-
-    public void setZaxis(String zaxis) {
-        this.zaxis = zaxis;
-    }
-
-    public String getTimestamp() {
-        return timestamp;
-    }
-
-    public void setTimestamp(String timestamp) {
-        this.timestamp = timestamp;
-    }
-
-    public String getUseYn() {
-        return useYn;
-    }
-
-    public void setUseYn(String useYn) {
-        this.useYn = useYn;
-    }
 }

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/dvc/service/DeviceAPIVO.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/dvc/service/DeviceAPIVO.java
@@ -18,17 +18,21 @@ package egovframework.hyb.mbl.dvc.service;
 import java.io.Serializable;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
 
-/**  
+/**
  * @Class Name : DeviceAPIVO.java
  * @Description : 통합 Device API VO Class
- * @Modification Information  
+ * @Modification Information
  * @
  * @ 수정일               수정자              수정내용
  * @ ----------   ---------   -------------------------------
  *   2025.10.28   통합개발팀          Android/iOS 패키지 통합
- * 
+ *
  */
+@Getter
+@Setter
 @Schema(description = "디바이스 API VO")
 public class DeviceAPIVO implements Serializable {
 
@@ -60,76 +64,4 @@ public class DeviceAPIVO implements Serializable {
 
     /** 활성화 여부 */
     private String useYn;
-
-    public int getSn() {
-        return sn;
-    }
-
-    public void setSn(int sn) {
-        this.sn = sn;
-    }
-
-    public String getUuid() {
-        return uuid;
-    }
-
-    public void setUuid(String uuid) {
-        this.uuid = uuid;
-    }
-
-    public String getOs() {
-        return os;
-    }
-
-    public void setOs(String os) {
-        this.os = os;
-    }
-
-    public String getTelno() {
-        return telno;
-    }
-
-    public void setTelno(String telno) {
-        this.telno = telno;
-    }
-
-    public String getStrgeInfo() {
-        return strgeInfo;
-    }
-
-    public void setStrgeInfo(String strgeInfo) {
-        this.strgeInfo = strgeInfo;
-    }
-
-    public String getNtwrkDeviceInfo() {
-        return ntwrkDeviceInfo;
-    }
-
-    public void setNtwrkDeviceInfo(String ntwrkDeviceInfo) {
-        this.ntwrkDeviceInfo = ntwrkDeviceInfo;
-    }
-
-    public String getPgVer() {
-        return pgVer;
-    }
-
-    public void setPgVer(String pgVer) {
-        this.pgVer = pgVer;
-    }
-
-    public String getDeviceNm() {
-        return deviceNm;
-    }
-
-    public void setDeviceNm(String deviceNm) {
-        this.deviceNm = deviceNm;
-    }
-
-    public String getUseYn() {
-        return useYn;
-    }
-
-    public void setUseYn(String useYn) {
-        this.useYn = useYn;
-    }
 }

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/fop/service/FileOpenerDeviceAPIVO.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/fop/service/FileOpenerDeviceAPIVO.java
@@ -5,6 +5,8 @@ import java.io.Serializable;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
 
 /**  
  * @Class Name : FileOpenerDeviceAPIVO.java
@@ -23,6 +25,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * 
  *  Copyright (C) by MOPAS All right reserved.
  */
+@Getter
+@Setter
 @Schema(description = "파일 오프너 디바이스 API VO")
 public class FileOpenerDeviceAPIVO implements Serializable {
 
@@ -48,62 +52,6 @@ public class FileOpenerDeviceAPIVO implements Serializable {
 	
 	@Schema(description = "파일번호")
     private int fileSn = 0;
-  	
-	public String getSn() {
-		return sn;
-	}
-
-	public void setSn(String sn) {
-		this.sn = sn;
-	}
-
-	public String getUuid() {
-		return uuid;
-	}
-
-	public void setUuid(String uuid) {
-		this.uuid = uuid;
-	}
-
-	public String getStreFileNm() {
-		return streFileNm;
-	}
-
-	public void setStreFileNm(String streFileNm) {
-		this.streFileNm = streFileNm;
-	}
-
-	public String getOrignlFileNm() {
-		return orignlFileNm;
-	}
-
-	public void setOrignlFileNm(String orignlFileNm) {
-		this.orignlFileNm = orignlFileNm;
-	}
-
-	public String getUpdDt() {
-		return updDt;
-	}
-
-	public void setUpdDt(String updDt) {
-		this.updDt = updDt;
-	}
-
-	public String getFileSize() {
-		return fileSize;
-	}
-
-	public void setFileSize(String fileSize) {
-		this.fileSize = fileSize;
-	}
-	
-	public int getFileSn() {
-		return fileSn;
-	}
-	
-	public void setFileSn(int fileSn) {
-		this.fileSn = fileSn;
-	}
 
 	/** String 타입의 값을 반환한다. */
     public String toString() {

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/frw/service/FileReaderWriterAPIVO.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/frw/service/FileReaderWriterAPIVO.java
@@ -18,17 +18,21 @@ package egovframework.hyb.mbl.frw.service;
 import java.io.Serializable;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
 
-/**  
+/**
  * @Class Name : FileReaderWriterAPIVO.java
  * @Description : 통합 FileReaderWriter API VO Class (Android/iOS 공통)
- * @Modification Information  
+ * @Modification Information
  * @
  * @ 수정일               수정자              수정내용
  * @ ----------   ---------   -------------------------------
  *   2025.10.28   통합개발팀          Android/iOS 패키지 통합
- * 
+ *
  */
+@Getter
+@Setter
 @Schema(description = "파일 읽기/쓰기 API VO")
 public class FileReaderWriterAPIVO implements Serializable {
 
@@ -78,124 +82,4 @@ public class FileReaderWriterAPIVO implements Serializable {
 
     /** resultMessage */
     private String resultMessage;
-
-    public int getSn() {
-        return sn;
-    }
-
-    public void setSn(int sn) {
-        this.sn = sn;
-    }
-
-    public String getUuid() {
-        return uuid;
-    }
-
-    public void setUuid(String uuid) {
-        this.uuid = uuid;
-    }
-
-    public int getFileSn() {
-        return fileSn;
-    }
-
-    public void setFileSn(int fileSn) {
-        this.fileSn = fileSn;
-    }
-
-    public String getFileNm() {
-        return fileNm;
-    }
-
-    public void setFileNm(String fileNm) {
-        this.fileNm = fileNm;
-    }
-
-    public String getFileType() {
-        return fileType;
-    }
-
-    public void setFileType(String fileType) {
-        this.fileType = fileType;
-    }
-
-    public String getUpdtDt() {
-        return updtDt;
-    }
-
-    public void setUpdtDt(String updtDt) {
-        this.updtDt = updtDt;
-    }
-
-    public String getUseYn() {
-        return useYn;
-    }
-
-    public void setUseYn(String useYn) {
-        this.useYn = useYn;
-    }
-
-    public String getFileStreCours() {
-        return fileStreCours;
-    }
-
-    public void setFileStreCours(String fileStreCours) {
-        this.fileStreCours = fileStreCours;
-    }
-
-    public String getStreFileNm() {
-        return streFileNm;
-    }
-
-    public void setStreFileNm(String streFileNm) {
-        this.streFileNm = streFileNm;
-    }
-
-    public String getOrignlFileNm() {
-        return orignlFileNm;
-    }
-
-    public void setOrignlFileNm(String orignlFileNm) {
-        this.orignlFileNm = orignlFileNm;
-    }
-
-    public String getFileExtsn() {
-        return fileExtsn;
-    }
-
-    public void setFileExtsn(String fileExtsn) {
-        this.fileExtsn = fileExtsn;
-    }
-
-    public String getFileCn() {
-        return fileCn;
-    }
-
-    public void setFileCn(String fileCn) {
-        this.fileCn = fileCn;
-    }
-
-    public String getFileSize() {
-        return fileSize;
-    }
-
-    public void setFileSize(String fileSize) {
-        this.fileSize = fileSize;
-    }
-
-    public String getResultState() {
-        return resultState;
-    }
-
-    public void setResultState(String resultState) {
-        this.resultState = resultState;
-    }
-
-    public String getResultMessage() {
-        return resultMessage;
-    }
-
-    public void setResultMessage(String resultMessage) {
-        this.resultMessage = resultMessage;
-    }
 }

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/gps/service/GPSAPIVO.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/gps/service/GPSAPIVO.java
@@ -18,17 +18,21 @@ package egovframework.hyb.mbl.gps.service;
 import java.io.Serializable;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
 
-/**  
+/**
  * @Class Name : GPSAPIVO.java
  * @Description : 통합 GPS API VO Class (Android/iOS 공통)
- * @Modification Information  
+ * @Modification Information
  * @
  * @ 수정일               수정자              수정내용
  * @ ----------   ---------   -------------------------------
  *   2025.10.28   통합개발팀          Android/iOS 패키지 통합
- * 
+ *
  */
+@Getter
+@Setter
 @Schema(description = "GPS API VO")
 public class GPSAPIVO implements Serializable {
 
@@ -57,68 +61,4 @@ public class GPSAPIVO implements Serializable {
 
     /** 결과 메시지 */
     private String resultMessage;
-
-    public int getSn() {
-        return sn;
-    }
-
-    public void setSn(int sn) {
-        this.sn = sn;
-    }
-
-    public String getUuid() {
-        return uuid;
-    }
-
-    public void setUuid(String uuid) {
-        this.uuid = uuid;
-    }
-
-    public String getLat() {
-        return lat;
-    }
-
-    public void setLat(String lat) {
-        this.lat = lat;
-    }
-
-    public String getLon() {
-        return lon;
-    }
-
-    public void setLon(String lon) {
-        this.lon = lon;
-    }
-
-    public String getAccrcy() {
-        return accrcy;
-    }
-
-    public void setAccrcy(String accrcy) {
-        this.accrcy = accrcy;
-    }
-
-    public String getUseYn() {
-        return useYn;
-    }
-
-    public void setUseYn(String useYn) {
-        this.useYn = useYn;
-    }
-
-    public String getResultState() {
-        return resultState;
-    }
-
-    public void setResultState(String resultState) {
-        this.resultState = resultState;
-    }
-
-    public String getResultMessage() {
-        return resultMessage;
-    }
-
-    public void setResultMessage(String resultMessage) {
-        this.resultMessage = resultMessage;
-    }
 }

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/itf/service/InterfaceAPIVO.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/itf/service/InterfaceAPIVO.java
@@ -21,17 +21,21 @@ import egovframework.hyb.validation.EgovNotNull;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
 
-/**  
+/**
  * @Class Name : InterfaceAPIVO.java
  * @Description : 통합 Interface API VO Class (Android/iOS 공통)
- * @Modification Information  
+ * @Modification Information
  * @
  * @ 수정일               수정자              수정내용
  * @ ----------   ---------   -------------------------------
  *   2025.10.28   통합개발팀          Android/iOS 패키지 통합
- * 
+ *
  */
+@Getter
+@Setter
 @Schema(description = "인터페이스 API VO")
 public class InterfaceAPIVO implements Serializable {
 
@@ -64,60 +68,4 @@ public class InterfaceAPIVO implements Serializable {
 
     /** resultMessage */
     private String resultMessage;
-
-    public int getSn() {
-        return sn;
-    }
-
-    public void setSn(int sn) {
-        this.sn = sn;
-    }
-
-    public String getUuid() {
-        return uuid;
-    }
-
-    public void setUuid(String uuid) {
-        this.uuid = uuid;
-    }
-
-    public String getUserId() {
-        return userId;
-    }
-
-    public void setUserId(String userId) {
-        this.userId = userId;
-    }
-
-    public String getUserPw() {
-        return userPw;
-    }
-
-    public void setUserPw(String userPw) {
-        this.userPw = userPw;
-    }
-
-    public String getEmails() {
-        return emails;
-    }
-
-    public void setEmails(String emails) {
-        this.emails = emails;
-    }
-
-    public String getResultState() {
-        return resultState;
-    }
-
-    public void setResultState(String resultState) {
-        this.resultState = resultState;
-    }
-
-    public String getResultMessage() {
-        return resultMessage;
-    }
-
-    public void setResultMessage(String resultMessage) {
-        this.resultMessage = resultMessage;
-    }
 }

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/mda/service/MediaAPIVO.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/mda/service/MediaAPIVO.java
@@ -19,17 +19,21 @@ import java.io.Serializable;
 
 import egovframework.hyb.utils.FileVO;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
 
-/**  
+/**
  * @Class Name : MediaAPIVO.java
  * @Description : 통합 Media API VO Class
- * @Modification Information  
+ * @Modification Information
  * @
  * @ 수정일               수정자              수정내용
  * @ ----------   ---------   -------------------------------
  *   2025.10.28   통합개발팀          Android/iOS 패키지 통합
- * 
+ *
  */
+@Getter
+@Setter
 @Schema(description = "미디어 API VO")
 public class MediaAPIVO extends FileVO implements Serializable {
 
@@ -55,60 +59,4 @@ public class MediaAPIVO extends FileVO implements Serializable {
 
     /** 재생횟수 */
     private String revivCo;
-
-    public int getSn() {
-        return sn;
-    }
-
-    public void setSn(int sn) {
-        this.sn = sn;
-    }
-
-    public String getUuid() {
-        return uuid;
-    }
-
-    public void setUuid(String uuid) {
-        this.uuid = uuid;
-    }
-
-    public int getFileSn() {
-        return fileSn;
-    }
-
-    public void setFileSn(int fileSn) {
-        this.fileSn = fileSn;
-    }
-
-    public String getMdCode() {
-        return mdCode;
-    }
-
-    public void setMdCode(String mdCode) {
-        this.mdCode = mdCode;
-    }
-
-    public String getMdSj() {
-        return mdSj;
-    }
-
-    public void setMdSj(String mdSj) {
-        this.mdSj = mdSj;
-    }
-
-    public String getUseyn() {
-        return useyn;
-    }
-
-    public void setUseyn(String useyn) {
-        this.useyn = useyn;
-    }
-
-    public String getRevivCo() {
-        return revivCo;
-    }
-
-    public void setRevivCo(String revivCo) {
-        this.revivCo = revivCo;
-    }
 }

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/nwk/service/NetworkAPIDefaultVO.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/nwk/service/NetworkAPIDefaultVO.java
@@ -17,21 +17,26 @@ package egovframework.hyb.mbl.nwk.service;
 
 import java.io.Serializable;
 
-/**  
+import lombok.Getter;
+import lombok.Setter;
+
+/**
  * @Class Name : NetworkAPIDefaultVO.java
  * @Description : 통합 Network API Default VO Class (Android/iOS 공통)
- * @Modification Information  
+ * @Modification Information
  * @
  * @ 수정일               수정자              수정내용
  * @ ----------   ---------   -------------------------------
  *   2025.10.28   통합개발팀          Android/iOS 패키지 통합
- * 
+ *
  * @author 디바이스 API 실행환경 팀
  * @since 2025. 10. 28.
  * @version 2.0
  * @see
- * 
+ *
  */
+@Getter
+@Setter
 public class NetworkAPIDefaultVO implements Serializable {
     
     private static final long serialVersionUID = 1L;
@@ -62,77 +67,5 @@ public class NetworkAPIDefaultVO implements Serializable {
 
     /** recordCountPerPage */
     private int recordCountPerPage = 10;
-
-    public String getSearchCondition() {
-        return searchCondition;
-    }
-
-    public void setSearchCondition(String searchCondition) {
-        this.searchCondition = searchCondition;
-    }
-
-    public String getSearchKeyword() {
-        return searchKeyword;
-    }
-
-    public void setSearchKeyword(String searchKeyword) {
-        this.searchKeyword = searchKeyword;
-    }
-
-    public String getSearchUseYn() {
-        return searchUseYn;
-    }
-
-    public void setSearchUseYn(String searchUseYn) {
-        this.searchUseYn = searchUseYn;
-    }
-
-    public int getPageIndex() {
-        return pageIndex;
-    }
-
-    public void setPageIndex(int pageIndex) {
-        this.pageIndex = pageIndex;
-    }
-
-    public int getPageUnit() {
-        return pageUnit;
-    }
-
-    public void setPageUnit(int pageUnit) {
-        this.pageUnit = pageUnit;
-    }
-
-    public int getPageSize() {
-        return pageSize;
-    }
-
-    public void setPageSize(int pageSize) {
-        this.pageSize = pageSize;
-    }
-
-    public int getFirstIndex() {
-        return firstIndex;
-    }
-
-    public void setFirstIndex(int firstIndex) {
-        this.firstIndex = firstIndex;
-    }
-
-    public int getLastIndex() {
-        return lastIndex;
-    }
-
-    public void setLastIndex(int lastIndex) {
-        this.lastIndex = lastIndex;
-    }
-
-    public int getRecordCountPerPage() {
-        return recordCountPerPage;
-    }
-
-    public void setRecordCountPerPage(int recordCountPerPage) {
-        this.recordCountPerPage = recordCountPerPage;
-    }
 }
 

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/nwk/service/NetworkAPIVO.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/nwk/service/NetworkAPIVO.java
@@ -18,22 +18,26 @@ package egovframework.hyb.mbl.nwk.service;
 import java.io.Serializable;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
 
-/**  
+/**
  * @Class Name : NetworkAPIVO.java
  * @Description : 통합 Network API VO Class
- * @Modification Information  
+ * @Modification Information
  * @
  * @ 수정일               수정자              수정내용
  * @ ----------   ---------   -------------------------------
  *   2025.10.28   통합개발팀          Android/iOS 패키지 통합
- * 
+ *
  * @author 디바이스 API 실행환경 팀
  * @since 2025. 10. 28.
  * @version 2.0
  * @see
- * 
+ *
  */
+@Getter
+@Setter
 @Schema(description = "네트워크 API VO")
 public class NetworkAPIVO extends NetworkAPIDefaultVO implements Serializable {
 
@@ -54,37 +58,5 @@ public class NetworkAPIVO extends NetworkAPIDefaultVO implements Serializable {
     /** 사용여부 */
     @Schema(description = "사용여부")
     private String useYn;
-
-    public int getSn() {
-        return sn;
-    }
-
-    public void setSn(int sn) {
-        this.sn = sn;
-    }
-
-    public String getUuid() {
-        return uuid;
-    }
-
-    public void setUuid(String uuid) {
-        this.uuid = uuid;
-    }
-
-    public String getNetworktype() {
-        return networktype;
-    }
-
-    public void setNetworktype(String networktype) {
-        this.networktype = networktype;
-    }
-
-    public String getUseYn() {
-        return useYn;
-    }
-
-    public void setUseYn(String useYn) {
-        this.useYn = useYn;
-    }
 }
 

--- a/device-api-web/src/main/java/egovframework/hyb/utils/FileVO.java
+++ b/device-api-web/src/main/java/egovframework/hyb/utils/FileVO.java
@@ -3,17 +3,21 @@ package egovframework.hyb.utils;
 import java.io.Serializable;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
 
-/**  
+/**
  * @Class Name : MediaAPIFileVO.java
  * @Description : 통합 Media API File VO Class
- * @Modification Information  
+ * @Modification Information
  * @
  * @ 수정일               수정자              수정내용
  * @ ----------   ---------   -------------------------------
  *   2025.10.28   통합개발팀          Android/iOS 패키지 통합
- * 
+ *
  */
+@Getter
+@Setter
 @Schema(description = "미디어 API 파일 업로드용 VO")
 public class FileVO implements Serializable {
 
@@ -57,108 +61,4 @@ public class FileVO implements Serializable {
 
     /** 재생 횟수 */
     private String revivCo;
-
-    public int getSn() {
-        return sn;
-    }
-
-    public void setSn(int sn) {
-        this.sn = sn;
-    }
-
-    public int getFileSn() {
-        return fileSn;
-    }
-
-    public void setFileSn(int fileSn) {
-        this.fileSn = fileSn;
-    }
-
-    public String getFileStreCours() {
-        return fileStreCours;
-    }
-
-    public void setFileStreCours(String fileStreCours) {
-        this.fileStreCours = fileStreCours;
-    }
-
-    public String getStreFileNm() {
-        return streFileNm;
-    }
-
-    public void setStreFileNm(String streFileNm) {
-        this.streFileNm = streFileNm;
-    }
-
-    public String getOrignlFileNm() {
-        return orignlFileNm;
-    }
-
-    public void setOrignlFileNm(String orignlFileNm) {
-        this.orignlFileNm = orignlFileNm;
-    }
-
-    public String getFileExtsn() {
-        return fileExtsn;
-    }
-
-    public void setFileExtsn(String fileExtsn) {
-        this.fileExtsn = fileExtsn;
-    }
-
-    public String getFileCn() {
-        return fileCn;
-    }
-
-    public void setFileCn(String fileCn) {
-        this.fileCn = fileCn;
-    }
-
-    public String getFileSize() {
-        return fileSize;
-    }
-
-    public void setFileSize(String fileSize) {
-        this.fileSize = fileSize;
-    }
-
-    public String getMdCode() {
-        return mdCode;
-    }
-
-    public void setMdCode(String mdCode) {
-        this.mdCode = mdCode;
-    }
-
-    public String getMdSj() {
-        return mdSj;
-    }
-
-    public void setMdSj(String mdSj) {
-        this.mdSj = mdSj;
-    }
-
-    public String getUuid() {
-        return uuid;
-    }
-
-    public void setUuid(String uuid) {
-        this.uuid = uuid;
-    }
-
-    public String getUseyn() {
-        return useyn;
-    }
-
-    public void setUseyn(String useyn) {
-        this.useyn = useyn;
-    }
-
-    public String getRevivCo() {
-        return revivCo;
-    }
-
-    public void setRevivCo(String revivCo) {
-        this.revivCo = revivCo;
-    }
 }


### PR DESCRIPTION
## 변경 사유

`device-api-web`의 VO 클래스 다수가 단순 위임 getter/setter로만 채워져 있어 Lombok으로 보일러플레이트를 줄였습니다.

## 변경 내용

다음 10개 VO 클래스에 클래스 레벨 `@Getter`/`@Setter`를 적용했습니다: `FileVO`, `FileOpenerDeviceAPIVO`, `GPSAPIVO`, `InterfaceAPIVO`, `DeviceAPIVO`, `MediaAPIVO`, `FileReaderWriterAPIVO`, `NetworkAPIVO`, `NetworkAPIDefaultVO`, `AcceleratorAPIVO`.

`@Schema`/`@Size`/`@Email` 등 필드 검증·문서화 애노테이션과 `FileOpenerDeviceAPIVO`의 커스텀 `toString()`은 그대로 유지했습니다.

## 테스트 방법 / 영향 범위

`mvn compile`로 정상 컴파일 확인했습니다. getter/setter 시그니처는 동일하게 유지되어 기존 호출부에 영향이 없습니다.

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] 테스트 통과 확인 (컴파일)