### PR TITLE
chore: 주석·README 한글 표기 오타 수정 (갯수→개수, 어플리케이션→애플리케이션)

### DIFF
--- a/device-api-app/README.md
+++ b/device-api-app/README.md
@@ -18,7 +18,7 @@ Clean Architecture 패턴을 적용했으며, GPS·가속도·미디어·파일�
 - [WebServer 실행](/docs/webserver.md)
 - [애뮬레이터 설치 및 실행](/docs/emulator.md)
 - [실기기에 Build 및 실행](/docs/device_build.md)
-- 어플리케이션 9종 안내
+- 애플리케이션 9종 안내
   - [가속도계(Accelerator)](/docs/applications/accelerator.md)
   - [파일 관리(File Management)](/docs/applications/file_management.md)
   - [기기 정보(Device Info)](/docs/applications/device_info.md)

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/nwk/service/EgovNetworkAPIService.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/nwk/service/EgovNetworkAPIService.java
@@ -47,9 +47,9 @@ public interface EgovNetworkAPIService {
     List<?> selectNetworkInfoList(Object vo) throws Exception;
 
     /**
-     * 네트워크 정보 총 갯수를 조회한다.
+     * 네트워크 정보 총 개수를 조회한다.
      * @param vo - 조회할 정보가 담긴 VO
-     * @return 네트워크 정보 총 갯수
+     * @return 네트워크 정보 총 개수
      * @exception
      */
     int selectNetworkInfoListTotCnt(Object vo);

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/nwk/service/NetworkAPIDefaultVO.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/nwk/service/NetworkAPIDefaultVO.java
@@ -48,7 +48,7 @@ public class NetworkAPIDefaultVO implements Serializable {
     /** 현재페이지 */
     private int pageIndex = 1;
     
-    /** 페이지갯수 */
+    /** 페이지개수 */
     private int pageUnit = 10;
     
     /** 페이지사이즈 */

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/nwk/service/impl/EgovNetworkAPIServiceImpl.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/nwk/service/impl/EgovNetworkAPIServiceImpl.java
@@ -110,9 +110,9 @@ public class EgovNetworkAPIServiceImpl extends EgovAbstractServiceImpl implement
     }
     
     /**
-     * 네트워크 정보 총 갯수를 조회한다.
+     * 네트워크 정보 총 개수를 조회한다.
      * @param vo - 조회할 정보가 담긴 VO
-     * @return 네트워크 정보 총 갯수
+     * @return 네트워크 정보 총 개수
      * @exception
      */
     public int selectNetworkInfoListTotCnt(Object vo) {

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/nwk/service/impl/NetworkAPIDAO.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/nwk/service/impl/NetworkAPIDAO.java
@@ -87,9 +87,9 @@ public class NetworkAPIDAO extends EgovAbstractMapper {
     }
 
     /**
-     * 네트워크 정보 총 갯수를 조회한다.
+     * 네트워크 정보 총 개수를 조회한다.
      * @param  vo - 조회할 정보가 담긴 NetworkAPIVO 또는 NetworkAPIDefaultVO
-     * @return 네트워크 정보 총 갯수
+     * @return 네트워크 정보 총 개수
      */
     public int selectNetworkInfoListTotCnt(Object vo) {
         return (Integer) selectOne("networkAPIDAO.selectNetworkInfoListTotCnt", vo);


### PR DESCRIPTION
## 변경 내용

device-api-web 소스 주석과 device-api-app README의 한글 표기 오타를 표준 표기로 수정했습니다. 코드 동작·식별자·문자열 리터럴 변경은 없습니다(주석·문서만).

- 갯수 → 개수: EgovNetworkAPIService, NetworkAPIDefaultVO, NetworkAPIDAO, EgovNetworkAPIServiceImpl 주석 7곳
- 어플리케이션 → 애플리케이션: device-api-app/README.md 1곳

총 5개 파일, 8줄 (+8 −8). 기존 파일의 줄바꿈은 원본 그대로 보존했습니다.

## 검증

- diff 전수가 주석·문서 라인만 포함함을 확인
- 같은 계열 병합 전례: egovframe-common-components #1090, template-simple-backend #163, template-simple-react #126(애플리케이션 표기)