### PR TITLE
build(maven): 버전 관리를 상위 POM으로 일원화

### DIFF
--- a/device-api-web/pom.xml
+++ b/device-api-web/pom.xml
@@ -6,7 +6,6 @@
 	<groupId>egovframework.lab</groupId>
 	<artifactId>egovframe-mobile-deviceapi</artifactId>
 	<packaging>jar</packaging>
-	<version>5.0.0</version>
 	<name>egovframe-mobile-deviceapi</name>
 	<url>http://www.egovframe.go.kr</url>
 
@@ -115,7 +114,6 @@
 		<dependency>
 			<groupId>jakarta.servlet</groupId>
 			<artifactId>jakarta.servlet-api</artifactId>
-			<version>${jakarta.servlet.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
## 개요

중복으로 선언된 Maven 버전 정보를 제거하고 상위 POM의 버전 관리 설정을 사용하도록 정리했습니다.

## 변경 사항

- 프로젝트의 명시적인 `5.0.0` 버전 선언 제거
  - `egovframe-boot-starter-parent`에서 프로젝트 버전을 상속
- `jakarta.servlet-api`의 명시적인 버전 선언 제거
  - 상위 POM의 의존성 관리 버전을 사용하도록 정렬

## 영향 범위

- 애플리케이션 소스 코드 변경 없음
- Maven 프로젝트 및 의존성 버전 관리 방식만 변경

## 검증

- JDK: Eclipse Adoptium 17.0.17
- Maven: 3.9.9
- `mvn -f device-api-web/pom.xml validate -DskipTests`
- 결과: `BUILD SUCCESS`