### PR TITLE
refactor(device-api): 사용하지 않는 import 제거

### DIFF
--- a/device-api-web/src/main/java/egovframework/hyb/mbl/fop/service/EgovFileOpenerDeviceAPIService.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/fop/service/EgovFileOpenerDeviceAPIService.java
@@ -17,9 +17,6 @@ package egovframework.hyb.mbl.fop.service;
 
 import java.util.List;
 
-import egovframework.hyb.utils.FileVO;
-
-
 /**  
  * @Class Name : EgovPushAPIService.java
  * @Description : EgovPushAPIService Class
@@ -28,6 +25,7 @@ import egovframework.hyb.utils.FileVO;
  * @  수정일       수정자                 수정내용
  * @ ---------   ---------   -------------------------------
  * @ 2016.07.11   장성호                 최초생성
+ *   2026.07.21  이백행          [2026년 컨트리뷰션] 사용하지 않는 import 제거
  * 
  * @author 디바이스 API 실행환경 개발팀
  * @since 2016. 07. 11

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/fop/service/impl/EgovFileOpenerDeviceAPIServiceImpl.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/fop/service/impl/EgovFileOpenerDeviceAPIServiceImpl.java
@@ -24,7 +24,6 @@ import org.springframework.stereotype.Service;
 
 import egovframework.hyb.mbl.fop.service.EgovFileOpenerDeviceAPIService;
 import egovframework.hyb.mbl.fop.service.FileOpenerDeviceAPIVO;
-import egovframework.hyb.utils.FileVO;
 import jakarta.annotation.Resource;
 
 
@@ -36,6 +35,7 @@ import jakarta.annotation.Resource;
  * @  수정일       수정자                   수정내용
  * @ ---------   ---------   -------------------------------
  * @ 2016.07.11   장성호                   최초생성
+ *   2026.07.21  이백행          [2026년 컨트리뷰션] 사용하지 않는 import 제거
  * 
  * @author 디바이스 API 실행환경 개발팀
  * @since 2016. 07.11

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/nwk/service/EgovNetworkAPIService.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/nwk/service/EgovNetworkAPIService.java
@@ -17,8 +17,15 @@ package egovframework.hyb.mbl.nwk.service;
 
 import java.util.List;
 
-import jakarta.servlet.http.HttpServletResponse;
-
+/**
+ * @Class Name : EgovNetworkAPIService.java
+ * @Description : 통합 Network API Service Class
+ * @Modification Information
+ * @
+ * @ 수정일         수정자        수정내용
+ * @ ----------   ---------   -----------------------------------------------------------
+ *   2026.07.21  이백행          [2026년 컨트리뷰션] 사용하지 않는 import 제거
+ */
 public interface EgovNetworkAPIService {
 
     /**

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/nwk/web/EgovNetworkAPIController.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/nwk/web/EgovNetworkAPIController.java
@@ -20,10 +20,14 @@ import egovframework.hyb.mbl.nwk.service.NetworkAPIVO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
-import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * 통합 Network API Controller
+ * @Modification Information
+ * @
+ * @ 수정일         수정자        수정내용
+ * @ ----------   ---------   -----------------------------------------------------------
+ *   2026.07.21  이백행          [2026년 컨트리뷰션] 사용하지 않는 import 제거
  */
 @Controller
 @Tag(name = "10. Network Guide Program Service", description = "네트워크 API 관리")


### PR DESCRIPTION
## 개요

Device API 소스에 남아 있는 사용하지 않는 import를 제거하여 Eclipse 경고를 해소합니다.

## 변경 사항

- File Opener 서비스 및 구현체에서 사용하지 않는 `FileVO` import 제거
- Network API 서비스 및 컨트롤러에서 사용하지 않는 `HttpServletResponse` import 제거
- 변경된 4개 Java 파일에 2026년 컨트리뷰션 개정이력 추가
- Network API 서비스 및 컨트롤러에 개정이력 영역 보완

## 변경 파일

- `EgovFileOpenerDeviceAPIService.java`
- `EgovFileOpenerDeviceAPIServiceImpl.java`
- `EgovNetworkAPIService.java`
- `EgovNetworkAPIController.java`

## 영향 범위

- 사용하지 않는 import와 문서 주석만 변경했습니다.
- 애플리케이션의 기능 및 API 동작에는 영향을 주지 않습니다.
- Eclipse의 `The import is never used` 경고 4건을 해소합니다.

## 검증

- JDK 17.0.17
- Maven 3.9.9
- `mvn clean test`
- 64개 Java 소스 컴파일 성공
- `BUILD SUCCESS`
- 테스트 소스가 없어 실행된 테스트는 없습니다.

<img width="1920" height="1080" alt="스크린샷 2026-07-21 201035" src="https://github.com/user-attachments/assets/4c1911dd-6bce-4a50-a03d-8a73d44f4afb" />
