### PR TITLE
refactor(mda): 미사용 파일 확장자 추출 메서드 제거

### DIFF
--- a/device-api-web/src/main/java/egovframework/hyb/mbl/mda/web/EgovMediaAPIController.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/mda/web/EgovMediaAPIController.java
@@ -228,12 +228,4 @@ public class EgovMediaAPIController {
         }
     }
 
-    // 파일 확장자 추출
-    private String getFileExtension(String filename) {
-        if (filename == null || filename.lastIndexOf(".") == -1) {
-            return "";
-        }
-        return filename.substring(filename.lastIndexOf("."));
-    }
-
 }


### PR DESCRIPTION
## 개요

`EgovMediaAPIController`에서 호출되지 않는 파일 확장자 추출 메서드를 제거합니다.

## 변경 사항

- 미사용 `getFileExtension(String)` private 메서드 제거
- 관련 Java 컴파일러 경고 해소

## 영향 범위

- 런타임 동작 및 외부 API 변경 없음
- 파일 확장자 처리는 기존 `EgovFileMngUtil` 구현을 그대로 사용

## 검증

- JDK 17.0.17
- Maven 3.9.9
- `mvn clean test`
- `BUILD SUCCESS`
- 테스트 소스가 없어 실행된 테스트는 없음

<img width="1920" height="1080" alt="스크린샷 2026-07-21 202126" src="https://github.com/user-attachments/assets/1b7cb176-85c7-4436-b973-a81d30f7ef73" />
