### PR TITLE
refactor(config): @Bean 메서드 접근 범위를 축소

### DIFF
--- a/device-api-web/src/main/java/egovframework/hyb/config/EgovConfigAspect.java
+++ b/device-api-web/src/main/java/egovframework/hyb/config/EgovConfigAspect.java
@@ -19,17 +19,17 @@ import egovframework.hyb.exception.EgovSampleOthersExcepHndlr;
 public class EgovConfigAspect {
 
 	@Bean
-	public EgovSampleExcepHndlr egovHandler() {
+	EgovSampleExcepHndlr egovHandler() {
 		return new EgovSampleExcepHndlr();
 	}
 
 	@Bean
-	public EgovSampleOthersExcepHndlr otherHandler() {
+	EgovSampleOthersExcepHndlr otherHandler() {
 		return new EgovSampleOthersExcepHndlr();
 	}
 
 	@Bean
-	public DefaultExceptionHandleManager defaultExceptionHandleManager(AntPathMatcher antPathMatcher, EgovSampleExcepHndlr egovHandler) {
+	DefaultExceptionHandleManager defaultExceptionHandleManager(AntPathMatcher antPathMatcher, EgovSampleExcepHndlr egovHandler) {
 		DefaultExceptionHandleManager defaultExceptionHandleManager = new DefaultExceptionHandleManager();
 		defaultExceptionHandleManager.setReqExpMatcher(antPathMatcher);
 		defaultExceptionHandleManager.setPatterns(new String[]{"**service.impl.*"});
@@ -38,7 +38,7 @@ public class EgovConfigAspect {
 	}
 
 	@Bean
-	public DefaultExceptionHandleManager otherExceptionHandleManager(AntPathMatcher antPathMatcher, EgovSampleOthersExcepHndlr othersExcepHndlr) {
+	DefaultExceptionHandleManager otherExceptionHandleManager(AntPathMatcher antPathMatcher, EgovSampleOthersExcepHndlr othersExcepHndlr) {
 		DefaultExceptionHandleManager defaultExceptionHandleManager = new DefaultExceptionHandleManager();
 		defaultExceptionHandleManager.setReqExpMatcher(antPathMatcher);
 		defaultExceptionHandleManager.setPatterns(new String[]{"**service.impl.*"});
@@ -47,7 +47,7 @@ public class EgovConfigAspect {
 	}
 
 	@Bean
-	public ExceptionTransfer exceptionTransfer(
+	ExceptionTransfer exceptionTransfer(
 		@Qualifier("defaultExceptionHandleManager") DefaultExceptionHandleManager defaultExceptionHandleManager,
 		@Qualifier("otherExceptionHandleManager") DefaultExceptionHandleManager otherExceptionHandleManager) {
 		ExceptionTransfer exceptionTransfer = new ExceptionTransfer();
@@ -58,7 +58,7 @@ public class EgovConfigAspect {
 	}
 
 	@Bean
-	public EgovAopExceptionTransfer aopExceptionTransfer(ExceptionTransfer exceptionTransfer) {
+	EgovAopExceptionTransfer aopExceptionTransfer(ExceptionTransfer exceptionTransfer) {
 		EgovAopExceptionTransfer egovAopExceptionTransfer = new EgovAopExceptionTransfer();
 		egovAopExceptionTransfer.setExceptionTransfer(exceptionTransfer);
 		return egovAopExceptionTransfer;

--- a/device-api-web/src/main/java/egovframework/hyb/config/EgovConfigCommon.java
+++ b/device-api-web/src/main/java/egovframework/hyb/config/EgovConfigCommon.java
@@ -15,17 +15,17 @@ import org.springframework.util.AntPathMatcher;
 public class EgovConfigCommon {
 
 	@Bean
-	public AntPathMatcher antPathMatcher() {
+	AntPathMatcher antPathMatcher() {
 		return new AntPathMatcher();
 	}
 
 	@Bean
-	public DefaultTraceHandler defaultTraceHandler() {
+	DefaultTraceHandler defaultTraceHandler() {
 		return new DefaultTraceHandler();
 	}
 
 	@Bean
-	public ReloadableResourceBundleMessageSource messageSource() {
+	ReloadableResourceBundleMessageSource messageSource() {
 		ReloadableResourceBundleMessageSource reloadableResourceBundleMessageSource = new ReloadableResourceBundleMessageSource();
 		reloadableResourceBundleMessageSource.setBasenames(
 				"classpath:/egovframework/message/message-common",
@@ -37,12 +37,12 @@ public class EgovConfigCommon {
 	}
 
 	@Bean
-	public MessageSourceAccessor messageSourceAccessor() {
+	MessageSourceAccessor messageSourceAccessor() {
 		return new MessageSourceAccessor(this.messageSource());
 	}
 
 	@Bean
-	public DefaultTraceHandleManager traceHandlerService() {
+	DefaultTraceHandleManager traceHandlerService() {
 		DefaultTraceHandleManager defaultTraceHandleManager = new DefaultTraceHandleManager();
 		defaultTraceHandleManager.setReqExpMatcher(antPathMatcher());
 		defaultTraceHandleManager.setPatterns(new String[]{"*"});
@@ -51,7 +51,7 @@ public class EgovConfigCommon {
 	}
 
 	@Bean
-	public LeaveaTrace leaveaTrace() {
+	LeaveaTrace leaveaTrace() {
 		LeaveaTrace leaveaTrace = new LeaveaTrace();
 		leaveaTrace.setTraceHandlerServices(new TraceHandlerService[]{traceHandlerService()});
 		return leaveaTrace;

--- a/device-api-web/src/main/java/egovframework/hyb/config/EgovConfigDatasource.java
+++ b/device-api-web/src/main/java/egovframework/hyb/config/EgovConfigDatasource.java
@@ -31,7 +31,7 @@ public class EgovConfigDatasource {
 	 * XML의 destroy-method="close"와 동일 (Spring Boot는 자동으로 close 메서드 인식)
 	 */
 	@Bean(name = "dataSource-mysql", destroyMethod = "close")
-	public DataSource dataSourceMysql() {
+	DataSource dataSourceMysql() {
 		BasicDataSource dataSource = new BasicDataSource();
 		dataSource.setDriverClassName(driverClassName);
 		dataSource.setUrl(url);
@@ -44,7 +44,7 @@ public class EgovConfigDatasource {
 	 * Oracle DataSource
 	 */
 	@Bean(name = "dataSource-oracle", destroyMethod = "close")
-	public DataSource dataSourceOracle() {
+	DataSource dataSourceOracle() {
 		BasicDataSource dataSource = new BasicDataSource();
 		dataSource.setDriverClassName(driverClassName);
 		dataSource.setUrl(url);
@@ -57,7 +57,7 @@ public class EgovConfigDatasource {
 	 * Altibase DataSource
 	 */
 	@Bean(name = "dataSource-altibase", destroyMethod = "close")
-	public DataSource dataSourceAltibase() {
+	DataSource dataSourceAltibase() {
 		BasicDataSource dataSource = new BasicDataSource();
 		dataSource.setDriverClassName(driverClassName);
 		dataSource.setUrl(url);
@@ -70,7 +70,7 @@ public class EgovConfigDatasource {
 	 * Tibero DataSource
 	 */
 	@Bean(name = "dataSource-tibero", destroyMethod = "close")
-	public DataSource dataSourceTibero() {
+	DataSource dataSourceTibero() {
 		BasicDataSource dataSource = new BasicDataSource();
 		dataSource.setDriverClassName(driverClassName);
 		dataSource.setUrl(url);
@@ -83,7 +83,7 @@ public class EgovConfigDatasource {
 	 * Cubrid DataSource
 	 */
 	@Bean(name = "dataSource-cubrid", destroyMethod = "close")
-	public DataSource dataSourceCubrid() {
+	DataSource dataSourceCubrid() {
 		BasicDataSource dataSource = new BasicDataSource();
 		dataSource.setDriverClassName(driverClassName);
 		dataSource.setUrl(url);
@@ -98,7 +98,7 @@ public class EgovConfigDatasource {
 	 */
 	@Bean(name = "dataSource")
 	@Primary
-	public DataSource dataSource() {
+	DataSource dataSource() {
 		switch (dbType.toLowerCase()) {
 			case "mysql":
 				return dataSourceMysql();

--- a/device-api-web/src/main/java/egovframework/hyb/config/EgovConfigIdGeneration.java
+++ b/device-api-web/src/main/java/egovframework/hyb/config/EgovConfigIdGeneration.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.Configuration;
 public class EgovConfigIdGeneration {
 
 	@Bean
-	public EgovIdGnrStrategyImpl mixPrefixSample() {
+	EgovIdGnrStrategyImpl mixPrefixSample() {
 		EgovIdGnrStrategyImpl egovIdGnrStrategyImpl = new EgovIdGnrStrategyImpl();
 		egovIdGnrStrategyImpl.setPrefix("SAMPLE-");
 		egovIdGnrStrategyImpl.setCipers(5);
@@ -21,7 +21,7 @@ public class EgovConfigIdGeneration {
 	}
 
 	@Bean(destroyMethod="destroy")
-	public EgovTableIdGnrServiceImpl egovIdGnrService(@Qualifier("dataSource") DataSource dataSource) {
+	EgovTableIdGnrServiceImpl egovIdGnrService(@Qualifier("dataSource") DataSource dataSource) {
 		EgovTableIdGnrServiceImpl egovTableIdGnrServiceImpl = new EgovTableIdGnrServiceImpl();
 		egovTableIdGnrServiceImpl.setDataSource(dataSource);
 		egovTableIdGnrServiceImpl.setStrategy(mixPrefixSample());
@@ -33,14 +33,14 @@ public class EgovConfigIdGeneration {
 	
 	// FILEUPLOAD IDGENERATION
 	@Bean
-	public EgovIdGnrStrategyImpl filePrefix() {
+	EgovIdGnrStrategyImpl filePrefix() {
 		EgovIdGnrStrategyImpl egovIdGnrStrategyImpl = new EgovIdGnrStrategyImpl();
 		egovIdGnrStrategyImpl.setCipers(10);
 		return egovIdGnrStrategyImpl;
 	}
 	
 	@Bean(name= "egovFileIdGnrService", destroyMethod = "destroy")
-	public EgovTableIdGnrServiceImpl egovFileIdGnrService(@Qualifier("dataSource") DataSource dataSource) {
+	EgovTableIdGnrServiceImpl egovFileIdGnrService(@Qualifier("dataSource") DataSource dataSource) {
 		EgovTableIdGnrServiceImpl egovTableIdGnrServiceImpl = new EgovTableIdGnrServiceImpl();
 		egovTableIdGnrServiceImpl.setDataSource(dataSource);
 		egovTableIdGnrServiceImpl.setStrategy(filePrefix());

--- a/device-api-web/src/main/java/egovframework/hyb/config/EgovConfigMapper.java
+++ b/device-api-web/src/main/java/egovframework/hyb/config/EgovConfigMapper.java
@@ -24,7 +24,7 @@ public class EgovConfigMapper {
 	private String dbType;
 
 	@Bean(name = "sqlSession")
-	public SqlSessionFactory sqlSessionFactory(@Qualifier("dataSource") DataSource dataSource) throws Exception {
+	SqlSessionFactory sqlSessionFactory(@Qualifier("dataSource") DataSource dataSource) throws Exception {
 		PathMatchingResourcePatternResolver pmrpr = new PathMatchingResourcePatternResolver();
 		SqlSessionFactoryBean sqlSessionFactoryBean = new SqlSessionFactoryBean();
 		sqlSessionFactoryBean.setDataSource(dataSource);
@@ -54,7 +54,7 @@ public class EgovConfigMapper {
 	}
 
 	@Bean(name = "sqlSessionTemplate")
-	public SqlSessionTemplate sqlSessionTemplate(SqlSessionFactory sqlSessionFactory) {
+	SqlSessionTemplate sqlSessionTemplate(SqlSessionFactory sqlSessionFactory) {
 		return new SqlSessionTemplate(sqlSessionFactory);
 	}
 

--- a/device-api-web/src/main/java/egovframework/hyb/config/EgovConfigProperties.java
+++ b/device-api-web/src/main/java/egovframework/hyb/config/EgovConfigProperties.java
@@ -11,7 +11,7 @@ import org.springframework.context.annotation.Configuration;
 public class EgovConfigProperties {
 
 	@Bean(destroyMethod="destroy")
-	public EgovPropertyServiceImpl propertiesService() {
+	EgovPropertyServiceImpl propertiesService() {
 		Map<String, String> properties = new HashMap<>();
 		properties.put("pageUnit", "10");
 		properties.put("pageSize", "10");

--- a/device-api-web/src/main/java/egovframework/hyb/config/EgovConfigTransaction.java
+++ b/device-api-web/src/main/java/egovframework/hyb/config/EgovConfigTransaction.java
@@ -23,14 +23,14 @@ import org.springframework.transaction.interceptor.TransactionInterceptor;
 public class EgovConfigTransaction {
 
 	@Bean(name="txManager")
-	public DataSourceTransactionManager txManager(@Qualifier("dataSource") DataSource dataSource) {
+	DataSourceTransactionManager txManager(@Qualifier("dataSource") DataSource dataSource) {
 		DataSourceTransactionManager dataSourceTransactionManager = new DataSourceTransactionManager();
 		dataSourceTransactionManager.setDataSource(dataSource);
 		return dataSourceTransactionManager;
 	}
 
 	@Bean
-	public TransactionInterceptor txAdvice(DataSourceTransactionManager txManager) {
+	TransactionInterceptor txAdvice(DataSourceTransactionManager txManager) {
 		RuleBasedTransactionAttribute txAttribute = new RuleBasedTransactionAttribute();
 		txAttribute.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRED);
 		txAttribute.setRollbackRules(Collections.singletonList(new RollbackRuleAttribute(Exception.class)));
@@ -49,7 +49,7 @@ public class EgovConfigTransaction {
 	}
 
 	@Bean
-	public Advisor txAdvisor(@Qualifier("txManager") DataSourceTransactionManager txManager) {
+	Advisor txAdvisor(@Qualifier("txManager") DataSourceTransactionManager txManager) {
 		AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
 		pointcut.setExpression("execution(* egovframework.hyb..impl.*Impl.*(..))");
 		return new DefaultPointcutAdvisor(pointcut, txAdvice(txManager));

--- a/device-api-web/src/main/java/egovframework/hyb/config/EgovConfigValidation.java
+++ b/device-api-web/src/main/java/egovframework/hyb/config/EgovConfigValidation.java
@@ -11,7 +11,7 @@ import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 public class EgovConfigValidation {
 
     @Bean
-    public Validator getValidator(@Qualifier("messageSource") MessageSource messageSource) {
+    Validator getValidator(@Qualifier("messageSource") MessageSource messageSource) {
         LocalValidatorFactoryBean localValidatorFactoryBean = new LocalValidatorFactoryBean();
         localValidatorFactoryBean.setValidationMessageSource(messageSource);
         return localValidatorFactoryBean;

--- a/device-api-web/src/main/java/egovframework/hyb/config/EgovConfigWeb.java
+++ b/device-api-web/src/main/java/egovframework/hyb/config/EgovConfigWeb.java
@@ -40,7 +40,7 @@ public class EgovConfigWeb implements WebMvcConfigurer, ApplicationContextAware 
 	}
 
 	@Bean
-	public SpringResourceTemplateResolver templateResolver() {
+	SpringResourceTemplateResolver templateResolver() {
 		SpringResourceTemplateResolver templateResolver = new SpringResourceTemplateResolver();
 		templateResolver.setApplicationContext(this.applicationContext);
 		templateResolver.setPrefix("classpath:/templates/thymeleaf/");
@@ -51,7 +51,7 @@ public class EgovConfigWeb implements WebMvcConfigurer, ApplicationContextAware 
 	}
 
 	@Bean
-	public SpringTemplateEngine templateEngine() {
+	SpringTemplateEngine templateEngine() {
 		SpringTemplateEngine templateEngine = new SpringTemplateEngine();
 		templateEngine.setTemplateResolver(templateResolver());
 		templateEngine.setEnableSpringELCompiler(true);
@@ -59,7 +59,7 @@ public class EgovConfigWeb implements WebMvcConfigurer, ApplicationContextAware 
 	}
 
 	@Bean
-	public ThymeleafViewResolver thymeleafViewResolver() {
+	ThymeleafViewResolver thymeleafViewResolver() {
 		ThymeleafViewResolver viewResolver = new ThymeleafViewResolver();
 		viewResolver.setCharacterEncoding("UTF-8");
 		viewResolver.setTemplateEngine(templateEngine());
@@ -83,12 +83,12 @@ public class EgovConfigWeb implements WebMvcConfigurer, ApplicationContextAware 
 	}
 
 	@Bean
-	public SessionLocaleResolver localeResolver() {
+	SessionLocaleResolver localeResolver() {
 		return new SessionLocaleResolver();
 	}
 
 	@Bean
-	public LocaleChangeInterceptor localeChangeInterceptor() {
+	LocaleChangeInterceptor localeChangeInterceptor() {
 		LocaleChangeInterceptor interceptor = new LocaleChangeInterceptor();
 		interceptor.setParamName("language");
 		return interceptor;

--- a/device-api-web/src/main/java/egovframework/hyb/config/FileUploadConfig.java
+++ b/device-api-web/src/main/java/egovframework/hyb/config/FileUploadConfig.java
@@ -12,7 +12,7 @@ import org.springframework.web.multipart.support.StandardServletMultipartResolve
 public class FileUploadConfig {
 
     @Bean
-    public MultipartResolver multipartResolver() {
+    MultipartResolver multipartResolver() {
         StandardServletMultipartResolver resolver = new StandardServletMultipartResolver();
         return resolver;
     }

--- a/device-api-web/src/main/java/egovframework/hyb/config/SpringDocConfig.java
+++ b/device-api-web/src/main/java/egovframework/hyb/config/SpringDocConfig.java
@@ -20,7 +20,7 @@ import io.swagger.v3.oas.models.info.License;
 public class SpringDocConfig {
 
 	@Bean
-	public OpenAPI openAPI() {
+	OpenAPI openAPI() {
 		return new OpenAPI().info(
 				new Info()
 				.title("표준프레임워크 DeviceAPI 연계서비스 (Hybrid App)")
@@ -32,7 +32,7 @@ public class SpringDocConfig {
 	}
 
 	@Bean
-	public GroupedOpenApi newsApiAll() {
+	GroupedOpenApi newsApiAll() {
 		return GroupedOpenApi.builder()
 				.group("00. All Device API REST Service")
 				.pathsToMatch("/**")
@@ -40,7 +40,7 @@ public class SpringDocConfig {
 	}
 
 	@Bean
-	public GroupedOpenApi acceleratorApi() {
+	GroupedOpenApi acceleratorApi() {
 		return GroupedOpenApi.builder()
 				.group("01. Accelerator Guide Program Service")
 				.pathsToMatch("/acl/**")
@@ -49,7 +49,7 @@ public class SpringDocConfig {
 	}
 
 	@Bean
-	public GroupedOpenApi cameraApi() {
+	GroupedOpenApi cameraApi() {
 		return GroupedOpenApi.builder()
 				.group("02. Camera Guide Program Service")
 				.pathsToMatch("/cmr/**")
@@ -57,7 +57,7 @@ public class SpringDocConfig {
 	}
 
 	@Bean
-	public GroupedOpenApi compassApi() {
+	GroupedOpenApi compassApi() {
 		return GroupedOpenApi.builder()
 				.group("03. Compass Guide Program Service")
 				.pathsToMatch("/cps/**")
@@ -65,7 +65,7 @@ public class SpringDocConfig {
 	}
 
 	@Bean
-	public GroupedOpenApi contactsApi() {
+	GroupedOpenApi contactsApi() {
 		return GroupedOpenApi.builder()
 				.group("04. Contacts Guide Program Service")
 				.pathsToMatch("/ctt/**")
@@ -73,7 +73,7 @@ public class SpringDocConfig {
 	}
 
 	@Bean
-	public GroupedOpenApi deviceApi() {
+	GroupedOpenApi deviceApi() {
 		return GroupedOpenApi.builder()
 				.group("05. DeviceInfo Guide Program Service")
 				.pathsToMatch("/dvc/**")
@@ -81,7 +81,7 @@ public class SpringDocConfig {
 	}
 
 	@Bean
-	public GroupedOpenApi fileReaderWriterApi() {
+	GroupedOpenApi fileReaderWriterApi() {
 		return GroupedOpenApi.builder()
 				.group("06. FileReaderWriter Guide Program Service")
 				.pathsToMatch("/frw/**")
@@ -89,7 +89,7 @@ public class SpringDocConfig {
 	}
 
 	@Bean
-	public GroupedOpenApi gpsApi() {
+	GroupedOpenApi gpsApi() {
 		return GroupedOpenApi.builder()
 				.group("07. GPS Guide Program Service")
 				.pathsToMatch("/gps/**")
@@ -97,7 +97,7 @@ public class SpringDocConfig {
 	}
 
 	@Bean
-	public GroupedOpenApi interfaceApi() {
+	GroupedOpenApi interfaceApi() {
 		return GroupedOpenApi.builder()
 				.group("08. Interface Guide Program Service")
 				.pathsToMatch("/itf/**")
@@ -105,7 +105,7 @@ public class SpringDocConfig {
 	}
 
 	@Bean
-	public GroupedOpenApi mediaApi() {
+	GroupedOpenApi mediaApi() {
 		return GroupedOpenApi.builder()
 				.group("09. Media Guide Program Service")
 				.pathsToMatch("/mda/**")
@@ -113,7 +113,7 @@ public class SpringDocConfig {
 	}
 
 	@Bean
-	public GroupedOpenApi networkApi() {
+	GroupedOpenApi networkApi() {
 		return GroupedOpenApi.builder()
 				.group("10. Network Guide Program Service")
 				.pathsToMatch("/nwk/**")
@@ -121,7 +121,7 @@ public class SpringDocConfig {
 	}
 
 	@Bean
-	public GroupedOpenApi vibratorApi() {
+	GroupedOpenApi vibratorApi() {
 		return GroupedOpenApi.builder()
 				.group("11. Vibrator Guide Program Service")
 				.pathsToMatch("/vbr/**")
@@ -129,7 +129,7 @@ public class SpringDocConfig {
 	}
 
 	@Bean
-	public GroupedOpenApi pushApi() {
+	GroupedOpenApi pushApi() {
 		return GroupedOpenApi.builder()
 				.group("12. PushNotifications Guide Program Service")
 				.pathsToMatch("/pus/**")
@@ -137,7 +137,7 @@ public class SpringDocConfig {
 	}
 
 	@Bean
-	public GroupedOpenApi fileOpenerApi() {
+	GroupedOpenApi fileOpenerApi() {
 		return GroupedOpenApi.builder()
 				.group("13. FileOpener Guide Program Service")
 				.pathsToMatch("/fop/**")
@@ -145,7 +145,7 @@ public class SpringDocConfig {
 	}
 
 	@Bean
-	public GroupedOpenApi streamingMediaApi() {
+	GroupedOpenApi streamingMediaApi() {
 		return GroupedOpenApi.builder()
 				.group("14. StreamingMedia Guide Program Service")
 				.pathsToMatch("/stm/**")
@@ -153,7 +153,7 @@ public class SpringDocConfig {
 	}
 
 	@Bean
-	public GroupedOpenApi barcodeScannerApi() {
+	GroupedOpenApi barcodeScannerApi() {
 		return GroupedOpenApi.builder()
 				.group("15. Barcodescanner Guide Program Service")
 				.pathsToMatch("/bar/**")
@@ -161,7 +161,7 @@ public class SpringDocConfig {
 	}
 
 	@Bean
-	public GroupedOpenApi resourceUpdateApi() {
+	GroupedOpenApi resourceUpdateApi() {
 		return GroupedOpenApi.builder()
 				.group("16. WebResourceUpdate Guide Program Service")
 				.pathsToMatch("/upd/**")
@@ -169,7 +169,7 @@ public class SpringDocConfig {
 	}
 
 	@Bean
-	public GroupedOpenApi jailbreakDetectionApi() {
+	GroupedOpenApi jailbreakDetectionApi() {
 		return GroupedOpenApi.builder()
 				.group("17. JailbreakDetection Guide Program Service")
 				.pathsToMatch("/jai/**")


### PR DESCRIPTION
## 개요

Spring 구성 클래스의 `@Bean` 팩토리 메서드에서 불필요한 `public`
접근 제한자를 제거합니다.

## 변경 사항

- 구성 클래스 11개 수정
- `@Bean` 메서드 54개의 접근 범위를 `public`에서 package-private으로 축소
- 빈 이름, 의존성 주입 시그니처 및 생성 로직 유지
- Spring Boot의 `JAVA_PUBLIC_BEAN_METHOD` 진단 경고 해소

## 영향도

- 애플리케이션의 빈 구성과 실행 동작에는 변화가 없습니다.
- 불필요하게 공개되던 구성 메서드의 접근 범위만 축소됩니다.

## 검증

- JDK 17.0.17
- Maven 3.9.9
- `mvn test`
- `BUILD SUCCESS`
- `git diff --check` 통과
- 공개 `@Bean` 메서드 잔여 패턴 없음

<img width="1920" height="1080" alt="스크린샷 2026-07-21 221305" src="https://github.com/user-attachments/assets/2d71df44-c4d8-42f1-8118-8bfd24398926" />

https://youtu.be/nKLABpfUk9k
