### PR TITLE
refactor(acl): 가속도계 API 계층 구조를 정리

### DIFF
--- a/device-api-web/src/main/java/egovframework/hyb/config/EgovConfigMapper.java
+++ b/device-api-web/src/main/java/egovframework/hyb/config/EgovConfigMapper.java
@@ -15,9 +15,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.stereotype.Repository;
 
 @Configuration
-@MapperScan(basePackages="egovframework.hyb")
+@MapperScan(basePackages="egovframework.hyb", annotationClass = Repository.class)
 public class EgovConfigMapper {
 
 	@Value("${Globals.DbType}")

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/acl/service/EgovAcceleratorAPIService.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/acl/service/EgovAcceleratorAPIService.java
@@ -7,10 +7,10 @@ import java.util.List;
  */
 public interface EgovAcceleratorAPIService {
 
-    List<?> selectAcceleratorInfoList(AcceleratorAPIVO searchVO) throws Exception;
+    List<AcceleratorAPIVO> selectAcceleratorInfoList(AcceleratorAPIVO searchVO);
 
-	int insertAcceleratorInfo(AcceleratorAPIVO vo) throws Exception;
+	int insertAcceleratorInfo(AcceleratorAPIVO vo);
 
-    int deleteAcceleratorInfo(AcceleratorAPIVO vo) throws Exception;
+    int deleteAcceleratorInfo(AcceleratorAPIVO vo);
 
 }

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/acl/service/impl/AcceleratorAPIDAO.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/acl/service/impl/AcceleratorAPIDAO.java
@@ -10,19 +10,19 @@ import egovframework.hyb.mbl.acl.service.AcceleratorAPIVO;
 /**
  * 통합 Accelerator API DAO
  */
-@Repository("AcceleratorAPIDAO")
+@Repository
 public class AcceleratorAPIDAO extends EgovAbstractMapper {
 
-    public List<?> selectAcceleratorInfoList(AcceleratorAPIVO searchVO) {
+    public List<AcceleratorAPIVO> selectAcceleratorInfoList(AcceleratorAPIVO searchVO) {
         return selectList("acceleratorAPIDAO.selectAcceleratorInfoList", searchVO);
     }
 
     public int insertAcceleratorInfo(AcceleratorAPIVO vo) {
-        return (Integer) insert("acceleratorAPIDAO.insertAcceleratorInfo", vo);
+        return insert("acceleratorAPIDAO.insertAcceleratorInfo", vo);
     }
 
     public int deleteAcceleratorInfo(AcceleratorAPIVO vo) {
-        return (Integer) delete("acceleratorAPIDAO.deleteAcceleratorInfo", vo);
+        return delete("acceleratorAPIDAO.deleteAcceleratorInfo", vo);
     }
 
 }

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/acl/service/impl/EgovAcceleratorAPIServiceImpl.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/acl/service/impl/EgovAcceleratorAPIServiceImpl.java
@@ -7,27 +7,30 @@ import org.springframework.stereotype.Service;
 
 import egovframework.hyb.mbl.acl.service.AcceleratorAPIVO;
 import egovframework.hyb.mbl.acl.service.EgovAcceleratorAPIService;
-import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 통합 Accelerator API ServiceImpl
  */
-@Service("EgovAcceleratorAPIService")
+@Service
+@RequiredArgsConstructor
+@Slf4j
 public class EgovAcceleratorAPIServiceImpl extends EgovAbstractServiceImpl implements EgovAcceleratorAPIService {
 
-    @Resource(name="AcceleratorAPIDAO")
-    private AcceleratorAPIDAO acceleratorAPIDAO;
+    private final AcceleratorAPIDAO acceleratorAPIDAO;
 
-    public List<?> selectAcceleratorInfoList(AcceleratorAPIVO searchVO) throws Exception {
+    public List<AcceleratorAPIVO> selectAcceleratorInfoList(AcceleratorAPIVO searchVO) {
+        log.debug("uuid={}", searchVO.getUuid());
         return acceleratorAPIDAO.selectAcceleratorInfoList(searchVO);
     }
     
-    public int insertAcceleratorInfo(AcceleratorAPIVO vo) throws Exception {
-        return (Integer) acceleratorAPIDAO.insertAcceleratorInfo(vo);
+    public int insertAcceleratorInfo(AcceleratorAPIVO vo) {
+        return acceleratorAPIDAO.insertAcceleratorInfo(vo);
     }
 
-    public int deleteAcceleratorInfo(AcceleratorAPIVO vo) throws Exception {
-        return (Integer) acceleratorAPIDAO.deleteAcceleratorInfo(vo);
+    public int deleteAcceleratorInfo(AcceleratorAPIVO vo) {
+        return acceleratorAPIDAO.deleteAcceleratorInfo(vo);
     }
 
 }

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/acl/web/EgovAcceleratorAPIController.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/acl/web/EgovAcceleratorAPIController.java
@@ -4,49 +4,44 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.egovframe.rte.fdl.property.EgovPropertyService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
-import org.springframework.ui.ModelMap;
-import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.support.SessionStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 
 import egovframework.hyb.mbl.acl.service.AcceleratorAPIVO;
 import egovframework.hyb.mbl.acl.service.EgovAcceleratorAPIService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 통합 Accelerator API Controller
  */
 @Controller
+@RequiredArgsConstructor
+@Slf4j
 @Tag(name = "01. Accelerator Guide Program Service", description = "가속도계 API 관리")
 public class EgovAcceleratorAPIController {
 
-    @Resource(name = "EgovAcceleratorAPIService")
-    private EgovAcceleratorAPIService egovAcceleratorAPIService;
-
-    @Resource(name = "propertiesService")
-    protected EgovPropertyService propertiesService;
+    private final EgovAcceleratorAPIService egovAcceleratorAPIService;
 
     @Operation(summary = "가속도계 정보 목록 조회", description = "가속도계 정보 목록을 조회합니다.")
-    @RequestMapping(value = "/acl/selectAcceleratorInfoList.do", method = RequestMethod.GET)
-    public ResponseEntity<?> selectAcceleratorInfoList(@ModelAttribute("searchVO") AcceleratorAPIVO searchVO, ModelMap model) throws Exception {
+    @GetMapping("/acl/selectAcceleratorInfoList.do")
+    public ResponseEntity<Map<String, Object>> selectAcceleratorInfoList(AcceleratorAPIVO searchVO) {
+        log.debug("uuid={}", searchVO.getUuid());
     	Map<String, Object> response = new HashMap<>();
-    	List<?> acceleratorInfoList = egovAcceleratorAPIService.selectAcceleratorInfoList(searchVO);
+    	List<AcceleratorAPIVO> acceleratorInfoList = egovAcceleratorAPIService.selectAcceleratorInfoList(searchVO);
         response.put("acceleratorInfoList", acceleratorInfoList);
         response.put("resultState", "OK");
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "가속도계 정보 등록", description = "가속도계 정보를 등록합니다.")
-    @RequestMapping(value = "/acl/insertAcceleratorInfo.do", method = RequestMethod.POST)
-    public ResponseEntity<?> insertAcceleratorInfo(AcceleratorAPIVO acceleratorVO, BindingResult bindingResult, Model model, SessionStatus status) throws Exception {
+    @PostMapping("/acl/insertAcceleratorInfo.do")
+    public ResponseEntity<Map<String, Object>> insertAcceleratorInfo(AcceleratorAPIVO acceleratorVO) {
         Map<String, Object> response = new HashMap<>();
         int cnt = egovAcceleratorAPIService.insertAcceleratorInfo(acceleratorVO);
         if (cnt > 0) {
@@ -60,8 +55,8 @@ public class EgovAcceleratorAPIController {
     }
 
     @Operation(summary = "가속도계 정보 삭제", description = "가속도계 정보를 삭제합니다.")
-    @RequestMapping(value = "/acl/deleteAcceleratorInfo.do", method = RequestMethod.DELETE)
-    public ResponseEntity<?> deleteAcceleratorInfo(AcceleratorAPIVO acceleratorVO, BindingResult bindingResult, Model model, SessionStatus status) throws Exception {
+    @DeleteMapping("/acl/deleteAcceleratorInfo.do")
+    public ResponseEntity<Map<String, Object>> deleteAcceleratorInfo(AcceleratorAPIVO acceleratorVO) {
         Map<String, Object> response = new HashMap<>();
         int cnt = egovAcceleratorAPIService.deleteAcceleratorInfo(acceleratorVO);
         if(cnt > 0) {


### PR DESCRIPTION
## 개요

가속도계 API의 컨트롤러, 서비스 및 DAO 계층을 정리하고 타입 안정성과 의존성 주입 방식을 개선합니다.

## 주요 변경 사항

- MyBatis 매퍼 스캔 대상을 `@Repository` 적용 클래스로 제한
- DAO 및 서비스의 명시적인 빈 이름 제거
- 필드 주입을 Lombok 기반 생성자 주입으로 변경
- 조회 결과를 `List<AcceleratorAPIVO>`로 구체화
- 불필요한 형 변환과 `throws Exception` 선언 제거
- `@RequestMapping`을 `@GetMapping`, `@PostMapping`, `@DeleteMapping`으로 구체화
- 컨트롤러 응답 타입을 `ResponseEntity<Map<String, Object>>`로 명확화
- UUID 확인을 위한 디버그 로그 추가
- 사용하지 않는 컨트롤러 의존성과 매개변수 제거

## 영향 범위

- `device-api-web`의 가속도계 API(`acl`) 계층
- MyBatis 매퍼 빈 검색 범위
- 기존 API URL, HTTP 메서드 및 응답 필드는 유지됨
- 데이터베이스 스키마 및 공개 API 계약 변경 없음
- Breaking Change 없음

## 테스트

- [x] `device-api-web` 빌드 및 단위 테스트
- [x] 가속도계 정보 목록 조회
- [x] 가속도계 정보 등록
- [x] 가속도계 정보 삭제
- [x] 애플리케이션 시작 시 Repository 및 MyBatis 매퍼 빈 등록 확인

https://youtu.be/LJvYoLoWPhc
