### PR TITLE
refactor(device-api): API 계층 구조와 타입 안전성을 개선

### DIFF
--- a/device-api-web/src/main/java/egovframework/hyb/mbl/dvc/service/EgovDeviceAPIService.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/dvc/service/EgovDeviceAPIService.java
@@ -7,13 +7,13 @@ import java.util.List;
  */
 public interface EgovDeviceAPIService {
 
-    int insertDeviceInfo(DeviceAPIVO vo) throws Exception;
+    int insertDeviceInfo(DeviceAPIVO vo);
 
-    int deleteDeviceInfo(DeviceAPIVO vo) throws Exception;
+    int deleteDeviceInfo(DeviceAPIVO vo);
 
-    DeviceAPIVO selectDeviceInfo(DeviceAPIVO vo) throws Exception;
+    DeviceAPIVO selectDeviceInfo(DeviceAPIVO vo);
 
-    List<?> selectDeviceInfoList(DeviceAPIVO searchVO) throws Exception;
+    List<DeviceAPIVO> selectDeviceInfoList(DeviceAPIVO searchVO);
 
-    int selectDeviceInfoListTotCnt(DeviceAPIVO searchVO) throws Exception;
+    int selectDeviceInfoListTotCnt(DeviceAPIVO searchVO);
 }

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/dvc/service/impl/DeviceAPIDAO.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/dvc/service/impl/DeviceAPIDAO.java
@@ -10,26 +10,26 @@ import egovframework.hyb.mbl.dvc.service.DeviceAPIVO;
 /**
  * 통합 Device API DAO
  */
-@Repository("DeviceAPIDAO")
+@Repository
 public class DeviceAPIDAO extends EgovAbstractMapper {
 
     public int insertDeviceInfo(DeviceAPIVO vo) {
-        return (Integer) insert("deviceAPIDAO.insertDeviceInfo", vo);
+        return insert("deviceAPIDAO.insertDeviceInfo", vo);
     }
 
     public int deleteDeviceInfo(DeviceAPIVO vo) {
-        return (Integer) delete("deviceAPIDAO.deleteDeviceInfo", vo);
+        return delete("deviceAPIDAO.deleteDeviceInfo", vo);
     }
 
     public DeviceAPIVO selectDeviceInfo(DeviceAPIVO vo) {
-        return (DeviceAPIVO) selectOne("deviceAPIDAO.selectDeviceInfo", vo);
+        return selectOne("deviceAPIDAO.selectDeviceInfo", vo);
     }
 
-    public List<?> selectDeviceInfoList(DeviceAPIVO searchVO) {
+    public List<DeviceAPIVO> selectDeviceInfoList(DeviceAPIVO searchVO) {
         return selectList("deviceAPIDAO.selectDeviceInfoList", searchVO);
     }
 
     public int selectDeviceInfoListTotCnt(DeviceAPIVO searchVO) {
-        return (Integer) selectOne("deviceAPIDAO.selectDeviceInfoListTotCnt", searchVO);
+        return selectOne("deviceAPIDAO.selectDeviceInfoListTotCnt", searchVO);
     }
 }

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/dvc/service/impl/EgovDeviceAPIServiceImpl.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/dvc/service/impl/EgovDeviceAPIServiceImpl.java
@@ -7,34 +7,37 @@ import org.springframework.stereotype.Service;
 
 import egovframework.hyb.mbl.dvc.service.DeviceAPIVO;
 import egovframework.hyb.mbl.dvc.service.EgovDeviceAPIService;
-import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 통합 Device API ServiceImpl
  */
-@Service("EgovDeviceAPIService")
+@Service
+@RequiredArgsConstructor
+@Slf4j
 public class EgovDeviceAPIServiceImpl extends EgovAbstractServiceImpl implements EgovDeviceAPIService {
 
-    @Resource(name="DeviceAPIDAO")
-    private DeviceAPIDAO deviceAPIDAO;
+    private final DeviceAPIDAO deviceAPIDAO;
 
-    public int insertDeviceInfo(DeviceAPIVO vo) throws Exception {
-        return (Integer) deviceAPIDAO.insertDeviceInfo(vo);
+    public int insertDeviceInfo(DeviceAPIVO vo) {
+        return deviceAPIDAO.insertDeviceInfo(vo);
     }
 
-    public int deleteDeviceInfo(DeviceAPIVO vo) throws Exception {
-        return (Integer) deviceAPIDAO.deleteDeviceInfo(vo);
+    public int deleteDeviceInfo(DeviceAPIVO vo) {
+        return deviceAPIDAO.deleteDeviceInfo(vo);
     }
 
-    public DeviceAPIVO selectDeviceInfo(DeviceAPIVO vo) throws Exception {
-        return (DeviceAPIVO) deviceAPIDAO.selectDeviceInfo(vo);
+    public DeviceAPIVO selectDeviceInfo(DeviceAPIVO vo) {
+        return deviceAPIDAO.selectDeviceInfo(vo);
     }
 
-    public List<?> selectDeviceInfoList(DeviceAPIVO searchVO) throws Exception {
+    public List<DeviceAPIVO> selectDeviceInfoList(DeviceAPIVO searchVO) {
+        log.debug("uuid={}", searchVO.getUuid());
         return deviceAPIDAO.selectDeviceInfoList(searchVO);
     }
 
-    public int selectDeviceInfoListTotCnt(DeviceAPIVO searchVO) throws Exception {
-        return (Integer) deviceAPIDAO.selectDeviceInfoListTotCnt(searchVO);
+    public int selectDeviceInfoListTotCnt(DeviceAPIVO searchVO) {
+        return deviceAPIDAO.selectDeviceInfoListTotCnt(searchVO);
     }
 }

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/dvc/web/EgovDeviceAPIController.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/dvc/web/EgovDeviceAPIController.java
@@ -4,49 +4,44 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.egovframe.rte.fdl.property.EgovPropertyService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
-import org.springframework.ui.ModelMap;
-import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.support.SessionStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 
 import egovframework.hyb.mbl.dvc.service.DeviceAPIVO;
 import egovframework.hyb.mbl.dvc.service.EgovDeviceAPIService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 통합 Device API Controller
  */
 @Controller
+@RequiredArgsConstructor
+@Slf4j
 @Tag(name = "05. DeviceInfo Guide Program Service", description = "디바이스 API 관리")
 public class EgovDeviceAPIController {
 
-    @Resource(name = "EgovDeviceAPIService")
-    private EgovDeviceAPIService egovDeviceAPIService;
-
-    @Resource(name = "propertiesService")
-    protected EgovPropertyService propertiesService;
+    private final EgovDeviceAPIService egovDeviceAPIService;
 
     @Operation(summary = "디바이스 정보 목록 조회", description = "디바이스 정보 목록을 조회합니다.")
-    @RequestMapping(value = "/dvc/selectDeviceInfoList.do", method = RequestMethod.GET)
-    public ResponseEntity<?> selectDeviceInfoList(@ModelAttribute("searchVO") DeviceAPIVO searchVO, ModelMap model) throws Exception {
+    @GetMapping("/dvc/selectDeviceInfoList.do")
+    public ResponseEntity<Map<String, Object>> selectDeviceInfoList(DeviceAPIVO searchVO) {
+        log.debug("uuid={}", searchVO.getUuid());
         Map<String, Object> response = new HashMap<>();
-        List<?> deviceInfoList = egovDeviceAPIService.selectDeviceInfoList(searchVO);
+        List<DeviceAPIVO> deviceInfoList = egovDeviceAPIService.selectDeviceInfoList(searchVO);
         response.put("deviceInfoList", deviceInfoList);
         response.put("resultState", "OK");
         return ResponseEntity.ok(response);
     }
     
     @Operation(summary = "디바이스 정보 상세 조회", description = "디바이스 정보를 조회합니다.")
-    @RequestMapping(value = "/dvc/selectDeviceInfo.do", method = RequestMethod.GET)
-    public ResponseEntity<?> selectDeviceInfo(@ModelAttribute("searchVO") DeviceAPIVO searchVO, ModelMap model) throws Exception {
+    @GetMapping("/dvc/selectDeviceInfo.do")
+    public ResponseEntity<Map<String, Object>> selectDeviceInfo(DeviceAPIVO searchVO) {
         Map<String, Object> response = new HashMap<>();
         searchVO = egovDeviceAPIService.selectDeviceInfo(searchVO);
         response.put("deviceInfo", searchVO);
@@ -55,8 +50,8 @@ public class EgovDeviceAPIController {
     }
 
     @Operation(summary = "디바이스 정보 등록", description = "디바이스 정보를 등록합니다.")
-    @RequestMapping(value = "/dvc/insertDeviceInfo.do", method = RequestMethod.POST)
-    public ResponseEntity<?> insertDeviceInfo(DeviceAPIVO deviceVO, BindingResult bindingResult, Model model, SessionStatus status) throws Exception {
+    @PostMapping("/dvc/insertDeviceInfo.do")
+    public ResponseEntity<Map<String, Object>> insertDeviceInfo(DeviceAPIVO deviceVO) {
         Map<String, Object> response = new HashMap<>();
         int cnt = egovDeviceAPIService.insertDeviceInfo(deviceVO);
         if(cnt > 0) {
@@ -70,8 +65,8 @@ public class EgovDeviceAPIController {
     }
 
     @Operation(summary = "디바이스 정보 삭제", description = "디바이스 정보를 삭제합니다.")
-    @RequestMapping(value = "/dvc/deleteDeviceInfo.do", method = RequestMethod.DELETE)
-    public ResponseEntity<?> deleteDeviceInfo(DeviceAPIVO deviceVO, BindingResult bindingResult, Model model, SessionStatus status) throws Exception {
+    @DeleteMapping("/dvc/deleteDeviceInfo.do")
+    public ResponseEntity<Map<String, Object>> deleteDeviceInfo(DeviceAPIVO deviceVO) {
         Map<String, Object> response = new HashMap<>();
         int cnt = egovDeviceAPIService.deleteDeviceInfo(deviceVO);
         if(cnt > 0) {


### PR DESCRIPTION
## 개요

디바이스 API의 컨트롤러, 서비스 및 DAO 계층을 정리하고 의존성 주입과 반환 타입의 안전성을 개선합니다.

## 주요 변경사항

- 서비스와 컨트롤러의 필드 주입을 `@RequiredArgsConstructor` 기반 생성자 주입으로 변경했습니다.
- DAO 호출부의 불필요한 명시적 형변환을 제거했습니다.
- 서비스 인터페이스와 구현체에서 불필요한 `throws Exception` 선언을 제거했습니다.
- 디바이스 목록의 반환 타입을 `List<?>`에서 `List<DeviceAPIVO>`로 구체화했습니다.
- `@RequestMapping`을 `@GetMapping`, `@PostMapping`, `@DeleteMapping`으로 단순화했습니다.
- 컨트롤러 응답 타입을 `ResponseEntity<Map<String, Object>>`로 명확히 지정했습니다.
- 사용하지 않는 컨트롤러 의존성과 메서드 인자를 제거했습니다.
- 목록 조회 시 UUID를 확인할 수 있는 디버그 로그를 추가했습니다.

## 영향 범위

- 디바이스 정보 목록 조회
- 디바이스 정보 상세 조회
- 디바이스 정보 등록
- 디바이스 정보 삭제
- MyBatis 매퍼 및 Spring 빈 검색

## 테스트 체크리스트

- [x] 애플리케이션 컨텍스트가 정상적으로 로딩되는지 확인
- [x] 디바이스 목록 조회 API가 정상 응답하는지 확인
- [x] 디바이스 상세 조회 API가 정상 응답하는지 확인
- [x] 디바이스 등록 API가 정상 처리되는지 확인
- [x] 디바이스 삭제 API가 정상 처리되는지 확인
- [x] MyBatis 매퍼와 DAO 빈이 정상적으로 등록되는지 확인

https://youtu.be/TH4HIzeTQQE
