### PR TITLE
fix(web): 파일 전송 처리를 개선

### DIFF
--- a/device-api-web/src/main/java/egovframework/hyb/mbl/frw/web/EgovFileReaderWriterAPIController.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/frw/web/EgovFileReaderWriterAPIController.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.egovframe.rte.fdl.property.EgovPropertyService;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.support.SessionStatus;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -113,9 +115,9 @@ public class EgovFileReaderWriterAPIController {
     }
     
     @Operation(summary = "파일 업로드", description = "파일을 업로드합니다. (단일 또는 여러 파일 지원, 확장자 제한 없음)")
-    @RequestMapping(value="/frw/fileupload.do", method = RequestMethod.POST)
+    @RequestMapping(value="/frw/fileupload.do", method = RequestMethod.POST, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> uploadFile(
-            @Parameter(description = "업로드할 파일") @RequestParam("files") MultipartFile[] files,
+            @Parameter(description = "업로드할 파일") @RequestPart("files") MultipartFile[] files,
             @Parameter(description = "기기 식별코드") @RequestParam("uuid") String uuid,
             HttpServletRequest request) throws Exception {
     	

--- a/device-api-web/src/main/java/egovframework/hyb/utils/EgovFileMngUtil.java
+++ b/device-api-web/src/main/java/egovframework/hyb/utils/EgovFileMngUtil.java
@@ -25,6 +25,9 @@ import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.web.multipart.MultipartFile;
@@ -230,13 +233,12 @@ public class EgovFileMngUtil extends EgovAbstractServiceImpl {
 			
 			// MIME 타입 설정
 			if (response != null) {
-				String originalFileName = fileVO.getOrignlFileNm();
-				response.setContentType("application/octet-stream");
+				response.setContentType(MediaType.APPLICATION_OCTET_STREAM_VALUE);
 				
 				// 파일명 인코딩
-				String encodedFileName = URLEncoder.encode(originalFileName, StandardCharsets.UTF_8).replace("+", "%20");
-				response.setHeader("Content-Disposition", 
-						"attachment; filename=\"" + originalFileName.replace("\"", "\\\"") + "\"; filename*=UTF-8''" + encodedFileName);
+				ContentDisposition contentDisposition = ContentDisposition.attachment()
+						.filename(fileVO.getOrignlFileNm(), StandardCharsets.UTF_8).build();
+				response.setHeader(HttpHeaders.CONTENT_DISPOSITION, contentDisposition.toString());
 			}
 			
 			buffer = new byte[(int) file.length()];


### PR DESCRIPTION
## 변경 사항

- 파일 업로드 API가 `multipart/form-data`를 소비하도록 명시했습니다.
- 업로드 파일 배열을 `@RequestPart("files")`로 바인딩하도록 변경했습니다.
- 다운로드 응답의 `Content-Type`과 `Content-Disposition`을 Spring 표준 API로 생성하도록 개선했습니다.
- 다운로드 파일명에 UTF-8 인코딩을 적용해 한글 및 특수문자 호환성을 높였습니다.

## 변경 이유

파일 업로드 요청 형식을 명확히 해 multipart 바인딩과 OpenAPI 문서 표현을 개선하고, 다운로드 헤더를 수동 조립하는 대신 Spring의 `ContentDisposition` API를 사용해 파일명 인코딩과 이스케이프 처리를 표준화합니다.

## 확인 사항

- `git diff --check` 통과
- 빌드 및 자동화 테스트는 실행하지 않음

테스트 전
- 파일 업로드 에러
<img width="1920" height="1080" alt="스크린샷 2026-08-05 181513" src="https://github.com/user-attachments/assets/c0d6404b-2b62-4342-855f-e0329af1694c" />
- 파일 다운로드 한글 깨짐
<img width="1920" height="1080" alt="스크린샷 2026-08-05 181713" src="https://github.com/user-attachments/assets/f7123b67-f253-4bf8-9ad5-440f23e07628" />

테스트 후
- 파일 다운로드 한글 깨짐 개선
<img width="1920" height="1080" alt="스크린샷 2026-08-05 182135" src="https://github.com/user-attachments/assets/e4f8261a-3599-4801-a315-ba5308385aaf" />

https://youtu.be/Pi3t95q_Yp4
