### PR TITLE
refactor(gps): GPS API 계층의 타입 안정성과 의존성 주입을 개선

### DIFF
--- a/device-api-web/src/main/java/egovframework/hyb/mbl/gps/service/EgovGPSAPIService.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/gps/service/EgovGPSAPIService.java
@@ -7,11 +7,11 @@ import java.util.List;
  */
 public interface EgovGPSAPIService {
 
-    int insertGPSInfo(GPSAPIVO vo) throws Exception;
+    int insertGPSInfo(GPSAPIVO vo);
 
-    int deleteGPSInfo(GPSAPIVO vo) throws Exception;
+    int deleteGPSInfo(GPSAPIVO vo);
 
-    List<?> selectGPSInfoList(GPSAPIVO searchVO) throws Exception;
+    List<GPSAPIVO> selectGPSInfoList(GPSAPIVO searchVO);
 
-    int selectGPSInfoListTotCnt(GPSAPIVO searchVO) throws Exception;
+    int selectGPSInfoListTotCnt(GPSAPIVO searchVO);
 }

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/gps/service/impl/EgovGPSAPIServiceImpl.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/gps/service/impl/EgovGPSAPIServiceImpl.java
@@ -7,30 +7,33 @@ import org.springframework.stereotype.Service;
 
 import egovframework.hyb.mbl.gps.service.EgovGPSAPIService;
 import egovframework.hyb.mbl.gps.service.GPSAPIVO;
-import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 통합 GPS API ServiceImpl
  */
-@Service("EgovGPSAPIService")
+@Service
+@RequiredArgsConstructor
+@Slf4j
 public class EgovGPSAPIServiceImpl extends EgovAbstractServiceImpl implements EgovGPSAPIService {
 
-    @Resource(name="GPSAPIDAO")
-    private GPSAPIDAO gpsAPIDAO;
+    private final GPSAPIDAO gpsAPIDAO;
 
-    public int insertGPSInfo(GPSAPIVO vo) throws Exception {
-        return (Integer) gpsAPIDAO.insertGPSInfo(vo);
+    public int insertGPSInfo(GPSAPIVO vo) {
+        return gpsAPIDAO.insertGPSInfo(vo);
     }
 
-    public int deleteGPSInfo(GPSAPIVO vo) throws Exception {
-        return (Integer) gpsAPIDAO.deleteGPSInfo(vo);
+    public int deleteGPSInfo(GPSAPIVO vo) {
+        return gpsAPIDAO.deleteGPSInfo(vo);
     }
 
-    public List<?> selectGPSInfoList(GPSAPIVO searchVO) throws Exception {
+    public List<GPSAPIVO> selectGPSInfoList(GPSAPIVO searchVO) {
+        log.debug("uuid={}", searchVO.getUuid());
         return gpsAPIDAO.selectGPSInfoList(searchVO);
     }
 
-    public int selectGPSInfoListTotCnt(GPSAPIVO searchVO) throws Exception {
-        return (Integer) gpsAPIDAO.selectGPSInfoListTotCnt(searchVO);
+    public int selectGPSInfoListTotCnt(GPSAPIVO searchVO) {
+        return gpsAPIDAO.selectGPSInfoListTotCnt(searchVO);
     }
 }

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/gps/service/impl/GPSAPIDAO.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/gps/service/impl/GPSAPIDAO.java
@@ -10,22 +10,22 @@ import egovframework.hyb.mbl.gps.service.GPSAPIVO;
 /**
  * 통합 GPS API DAO
  */
-@Repository("GPSAPIDAO")
+@Repository
 public class GPSAPIDAO extends EgovAbstractMapper {
 
     public int insertGPSInfo(GPSAPIVO vo) {
-        return (Integer) insert("gpsAPIDAO.insertGPSInfo", vo);
+        return insert("gpsAPIDAO.insertGPSInfo", vo);
     }
 
     public int deleteGPSInfo(GPSAPIVO vo) {
-        return (Integer) delete("gpsAPIDAO.deleteGPSInfo", vo);
+        return delete("gpsAPIDAO.deleteGPSInfo", vo);
     }
 
-    public List<?> selectGPSInfoList(GPSAPIVO searchVO) {
+    public List<GPSAPIVO> selectGPSInfoList(GPSAPIVO searchVO) {
         return selectList("gpsAPIDAO.selectGPSInfoList", searchVO);
     }
 
     public int selectGPSInfoListTotCnt(GPSAPIVO searchVO) {
-        return (Integer) selectOne("gpsAPIDAO.selectGPSInfoListTotCnt", searchVO);
+        return selectOne("gpsAPIDAO.selectGPSInfoListTotCnt", searchVO);
     }
 }

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/gps/web/EgovGPSAPIController.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/gps/web/EgovGPSAPIController.java
@@ -4,49 +4,44 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.egovframe.rte.fdl.property.EgovPropertyService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
-import org.springframework.ui.ModelMap;
-import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.support.SessionStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 
 import egovframework.hyb.mbl.gps.service.EgovGPSAPIService;
 import egovframework.hyb.mbl.gps.service.GPSAPIVO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 통합 GPS API Controller
  */
 @Controller
+@RequiredArgsConstructor
+@Slf4j
 @Tag(name = "07. GPS Guide Program Service", description = "GPS API 관리")
 public class EgovGPSAPIController {
 
-    @Resource(name = "EgovGPSAPIService")
-    private EgovGPSAPIService egovGPSAPIService;
-
-    @Resource(name = "propertiesService")
-    protected EgovPropertyService propertiesService;
+    private final EgovGPSAPIService egovGPSAPIService;
 
     @Operation(summary = "GPS 정보 목록 조회", description = "GPS 정보 목록을 조회합니다.")
-    @RequestMapping(value = "/gps/selectGPSInfoList.do", method = RequestMethod.GET)
-    public ResponseEntity<?> selectGPSInfoList(@ModelAttribute("searchVO") GPSAPIVO searchVO, ModelMap model) throws Exception {
+    @GetMapping("/gps/selectGPSInfoList.do")
+    public ResponseEntity<Map<String, Object>> selectGPSInfoList(GPSAPIVO searchVO) {
+        log.debug("uuid={}", searchVO.getUuid());
         Map<String, Object> response = new HashMap<>();
-        List<?> gpsInfoList = egovGPSAPIService.selectGPSInfoList(searchVO);
+        List<GPSAPIVO> gpsInfoList = egovGPSAPIService.selectGPSInfoList(searchVO);
         response.put("gpsInfoList", gpsInfoList);
         response.put("resultState", "OK");
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "GPS 정보 등록", description = "GPS 정보를 등록합니다.")
-    @RequestMapping(value = "/gps/insertGPSInfo.do", method = RequestMethod.POST)
-    public ResponseEntity<?> insertGPSInfo(GPSAPIVO gpsVO, BindingResult bindingResult, Model model, SessionStatus status) throws Exception {
+    @PostMapping("/gps/insertGPSInfo.do")
+    public ResponseEntity<Map<String, Object>> insertGPSInfo(GPSAPIVO gpsVO) {
         Map<String, Object> response = new HashMap<>();
         
         int cnt = egovGPSAPIService.insertGPSInfo(gpsVO);
@@ -61,8 +56,8 @@ public class EgovGPSAPIController {
     }
 
     @Operation(summary = "GPS 정보 삭제", description = "GPS 정보를 삭제합니다.")
-    @RequestMapping(value = "/gps/deleteGPSInfo.do", method = RequestMethod.DELETE)
-    public ResponseEntity<?> deleteGPSInfo(GPSAPIVO sampleVO, @ModelAttribute("searchVO") GPSAPIVO searchVO, SessionStatus status) throws Exception {
+    @DeleteMapping("/gps/deleteGPSInfo.do")
+    public ResponseEntity<Map<String, Object>> deleteGPSInfo(GPSAPIVO sampleVO) {
     	Map<String, Object> response = new HashMap<>();
     	int cnt = egovGPSAPIService.deleteGPSInfo(sampleVO);
     	if(cnt > 0) {


### PR DESCRIPTION
##  개요

GPS API 계층의 필드 주입과 범용 타입을 정리하고, 생성자 기반 의존성 주입과 구체적인 제네릭 타입을 적용합니다.

##  주요 변경 사항

- `@Resource` 필드 주입을 `@RequiredArgsConstructor` 기반 생성자 주입으로 변경
- 서비스와 DAO의 명시적인 빈 이름 제거
- `@RequestMapping`을 `@GetMapping`, `@PostMapping`, `@DeleteMapping`으로 구체화
- `List<?>`를 `List<GPSAPIVO>`로 변경
- `ResponseEntity<?>`를 `ResponseEntity<Map<String, Object>>`로 변경
- 사용하지 않는 Property Service와 MVC 메서드 인자 제거
- 불필요한 `throws Exception` 선언과 반환값 형변환 제거
- GPS 목록 조회 시 UUID 디버그 로그 추가

##  영향 범위

- 기존 GPS API URL과 HTTP 메서드는 유지됩니다.
- 기존 응답 필드인 `gpsInfoList`, `resultState`, `resultMessage`는 유지됩니다.
- GPS 서비스와 DAO의 반환 타입이 구체화되어 컴파일 시 타입 검증이 강화됩니다.
- 의존성 주입 방식이 빈 이름 기반에서 타입 기반으로 변경됩니다.

##  검증

- `git diff --check` 통과
- 빌드 및 자동화 테스트는 실행하지 않음

##  테스트 체크리스트

- [x] GPS 정보 목록 조회
- [x] GPS 정보 등록
- [x] GPS 정보 삭제
- [x] 애플리케이션 컨텍스트 및 GPS 관련 빈 정상 생성 확인

http://localhost:9700/swagger-ui/index.html#/07.%20GPS%20Guide%20Program%20Service

https://youtu.be/7VO9a-8fYRI
