### PR TITLE
feat(interface): 사용자 계정 기반 API와 DB 매핑을 확장한다

### DIFF
--- a/device-api-web/src/main/java/egovframework/hyb/mbl/itf/service/EgovInterfaceAPIService.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/itf/service/EgovInterfaceAPIService.java
@@ -7,15 +7,15 @@ import java.util.List;
  */
 public interface EgovInterfaceAPIService {
 
-    int insertInterfaceInfo(InterfaceAPIVO vo) throws Exception;
+    int insertInterfaceInfo(InterfaceAPIVO vo);
 
-    int updateInterfaceInfo(InterfaceAPIVO vo) throws Exception;
+    int updateInterfaceInfo(InterfaceAPIVO vo);
 
-    int deleteInterfaceInfo(InterfaceAPIVO vo) throws Exception;
+    int deleteInterfaceInfo(InterfaceAPIVO vo);
 
-    InterfaceAPIVO selectInterfaceInfo(InterfaceAPIVO vo) throws Exception;
+    InterfaceAPIVO selectInterfaceInfo(InterfaceAPIVO vo);
 
-    List<?> selectInterfaceInfoList(InterfaceAPIVO searchVO) throws Exception;
+    List<InterfaceAPIVO> selectInterfaceInfoList(InterfaceAPIVO searchVO);
 
-    int selectInterfaceInfoListTotCnt(InterfaceAPIVO searchVO) throws Exception;
+    int selectInterfaceInfoListTotCnt(InterfaceAPIVO searchVO);
 }

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/itf/service/impl/EgovInterfaceAPIServiceImpl.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/itf/service/impl/EgovInterfaceAPIServiceImpl.java
@@ -7,39 +7,42 @@ import org.springframework.stereotype.Service;
 
 import egovframework.hyb.mbl.itf.service.EgovInterfaceAPIService;
 import egovframework.hyb.mbl.itf.service.InterfaceAPIVO;
-import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 통합 Interface API ServiceImpl.
  * 비밀번호는 앱에서 1차 해시(SHA-256+userId, Base64)한 값을 그대로 DB에 저장·비교한다.
  */
-@Service("EgovInterfaceAPIService")
+@Service
+@RequiredArgsConstructor
+@Slf4j
 public class EgovInterfaceAPIServiceImpl extends EgovAbstractServiceImpl implements EgovInterfaceAPIService {
 
-    @Resource(name="InterfaceAPIDAO")
-    private InterfaceAPIDAO interfaceAPIDAO;
+    private final InterfaceAPIDAO interfaceAPIDAO;
 
-    public int insertInterfaceInfo(InterfaceAPIVO vo) throws Exception {
-        return (Integer) interfaceAPIDAO.insertInterfaceInfo(vo);
+    public int insertInterfaceInfo(InterfaceAPIVO vo) {
+        return interfaceAPIDAO.insertInterfaceInfo(vo);
     }
 
-    public int updateInterfaceInfo(InterfaceAPIVO vo) throws Exception {
-        return (Integer) interfaceAPIDAO.updateInterfaceInfo(vo);
+    public int updateInterfaceInfo(InterfaceAPIVO vo) {
+        return interfaceAPIDAO.updateInterfaceInfo(vo);
     }
 
-    public int deleteInterfaceInfo(InterfaceAPIVO vo) throws Exception {
-        return (Integer) interfaceAPIDAO.deleteInterfaceInfo(vo);
+    public int deleteInterfaceInfo(InterfaceAPIVO vo) {
+        return interfaceAPIDAO.deleteInterfaceInfo(vo);
     }
 
-    public InterfaceAPIVO selectInterfaceInfo(InterfaceAPIVO vo) throws Exception {
-        return (InterfaceAPIVO) interfaceAPIDAO.selectInterfaceInfo(vo);
+    public InterfaceAPIVO selectInterfaceInfo(InterfaceAPIVO vo) {
+        return interfaceAPIDAO.selectInterfaceInfo(vo);
     }
 
-    public List<?> selectInterfaceInfoList(InterfaceAPIVO searchVO) throws Exception {
+    public List<InterfaceAPIVO> selectInterfaceInfoList(InterfaceAPIVO searchVO) {
+        log.debug("userId={}", searchVO.getUserId());
         return interfaceAPIDAO.selectInterfaceInfoList(searchVO);
     }
 
-    public int selectInterfaceInfoListTotCnt(InterfaceAPIVO searchVO) throws Exception {
-        return (Integer) interfaceAPIDAO.selectInterfaceInfoListTotCnt(searchVO);
+    public int selectInterfaceInfoListTotCnt(InterfaceAPIVO searchVO) {
+        return interfaceAPIDAO.selectInterfaceInfoListTotCnt(searchVO);
     }
 }

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/itf/service/impl/InterfaceAPIDAO.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/itf/service/impl/InterfaceAPIDAO.java
@@ -10,30 +10,30 @@ import egovframework.hyb.mbl.itf.service.InterfaceAPIVO;
 /**
  * 통합 Interface API DAO
  */
-@Repository("InterfaceAPIDAO")
+@Repository
 public class InterfaceAPIDAO extends EgovAbstractMapper {
 
     public int insertInterfaceInfo(InterfaceAPIVO vo) {
-        return (Integer) insert("interfaceAPIDAO.insertInterfaceInfo", vo);
+        return insert("interfaceAPIDAO.insertInterfaceInfo", vo);
     }
 
     public int updateInterfaceInfo(InterfaceAPIVO vo) {
-        return (Integer) update("interfaceAPIDAO.updateInterfaceInfo", vo);
+        return update("interfaceAPIDAO.updateInterfaceInfo", vo);
     }
 
     public int deleteInterfaceInfo(InterfaceAPIVO vo) {
-        return (Integer) delete("interfaceAPIDAO.deleteInterfaceInfo", vo);
+        return delete("interfaceAPIDAO.deleteInterfaceInfo", vo);
     }
 
     public InterfaceAPIVO selectInterfaceInfo(InterfaceAPIVO vo) {
         return (InterfaceAPIVO) selectOne("interfaceAPIDAO.selectInterfaceInfo", vo);
     }
 
-    public List<?> selectInterfaceInfoList(InterfaceAPIVO searchVO) {
+    public List<InterfaceAPIVO> selectInterfaceInfoList(InterfaceAPIVO searchVO) {
         return selectList("interfaceAPIDAO.selectInterfaceInfoList", searchVO);
     }
 
     public int selectInterfaceInfoListTotCnt(InterfaceAPIVO searchVO) {
-        return (Integer) selectOne("interfaceAPIDAO.selectInterfaceInfoListTotCnt", searchVO);
+        return selectOne("interfaceAPIDAO.selectInterfaceInfoListTotCnt", searchVO);
     }
 }

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/itf/web/EgovInterfaceAPIController.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/itf/web/EgovInterfaceAPIController.java
@@ -4,53 +4,51 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.egovframe.rte.fdl.property.EgovPropertyService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.ui.ModelMap;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.support.SessionStatus;
 
 import egovframework.hyb.mbl.itf.service.EgovInterfaceAPIService;
 import egovframework.hyb.mbl.itf.service.InterfaceAPIVO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.annotation.Resource;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 통합 Interface API Controller
  */
 @Controller
+@RequiredArgsConstructor
+@Slf4j
 @Tag(name = "08. Interface Guide Program Service", description = "인터페이스 API 관리")
 public class EgovInterfaceAPIController {
 
-    @Resource(name = "EgovInterfaceAPIService")
-    private EgovInterfaceAPIService egovInterfaceAPIService;
-
-    @Resource(name = "propertiesService")
-    protected EgovPropertyService propertiesService;
+    private final EgovInterfaceAPIService egovInterfaceAPIService;
 
     @Operation(summary = "인터페이스 정보 목록 조회", description = "인터페이스 정보 목록을 조회합니다.")
-    @RequestMapping(value = "/itf/selectInterfaceInfoList.do", method = RequestMethod.GET)
-    public ResponseEntity<?> selectInterfaceInfoList(@ModelAttribute("searchVO") InterfaceAPIVO searchVO, ModelMap model) throws Exception {
+    @GetMapping("/itf/selectInterfaceInfoList.do")
+    public ResponseEntity<Map<String, Object>> selectInterfaceInfoList(InterfaceAPIVO searchVO) {
+        log.debug("userId={}", searchVO.getUserId());
         Map<String, Object> response = new HashMap<>();
-        List<?> interfaceInfoList = egovInterfaceAPIService.selectInterfaceInfoList(searchVO);
+        List<InterfaceAPIVO> interfaceInfoList = egovInterfaceAPIService.selectInterfaceInfoList(searchVO);
         response.put("interfaceInfoList", interfaceInfoList);
         response.put("resultState", "OK");
         return ResponseEntity.ok(response);
     }
     
     @Operation(summary = "인터페이스 로그인 조회", description = "인터페이스 로그인을 한다.")
-    @RequestMapping(value= "/itf/loginInterfaceInfo.do", method = RequestMethod.POST)
-    public ResponseEntity<?> loginInterfaceInfo(
-            @Valid @ModelAttribute("searchVO") InterfaceAPIVO searchVO,
-            BindingResult bindingResult,
-            ModelMap model) throws Exception {
+    @PostMapping("/itf/loginInterfaceInfo.do")
+    public ResponseEntity<Map<String, Object>> loginInterfaceInfo(
+            @Valid InterfaceAPIVO searchVO,
+            BindingResult bindingResult) {
     	Map<String, Object> response = new HashMap<>();
     	if (bindingResult.hasErrors()) {
     		return ResponseEntity.ok(validationErrorResponse(bindingResult));
@@ -74,11 +72,10 @@ public class EgovInterfaceAPIController {
     }
     
     @Operation(summary = "인터페이스 정보 조회", description = "인터페이스 정보를 조회한다.")
-    @RequestMapping(value= "/itf/selectInterfaceInfo.do", method = RequestMethod.POST)
-    public ResponseEntity<?> selectInterfaceInfo(
-            @Valid @ModelAttribute("searchVO") InterfaceAPIVO searchVO,
-            BindingResult bindingResult,
-            ModelMap model) throws Exception {
+    @GetMapping("/itf/selectInterfaceInfo.do")
+    public ResponseEntity<Map<String, Object>> selectInterfaceInfo(
+            @Valid InterfaceAPIVO searchVO,
+            BindingResult bindingResult) {
     	Map<String, Object> response = new HashMap<>();
     	if (bindingResult.hasErrors()) {
     		return ResponseEntity.ok(validationErrorResponse(bindingResult));
@@ -94,12 +91,12 @@ public class EgovInterfaceAPIController {
     }
 
     @Operation(summary = "인터페이스 정보 등록", description = "인터페이스 정보를 등록합니다.")
-    @RequestMapping(value = "/itf/insertInterfaceInfo.do", method = RequestMethod.POST)
-    public ResponseEntity<?> insertInterfaceInfo(
+    @PostMapping("/itf/insertInterfaceInfo.do")
+    public ResponseEntity<Map<String, Object>> insertInterfaceInfo(
             @Valid @ModelAttribute("interfaceVO") InterfaceAPIVO interfaceVO,
             BindingResult bindingResult,
             Model model,
-            SessionStatus status) throws Exception {
+            SessionStatus status) {
         Map<String, Object> response = new HashMap<>();
         if (bindingResult.hasErrors()) {
             return ResponseEntity.ok(validationErrorResponse(bindingResult));
@@ -121,12 +118,10 @@ public class EgovInterfaceAPIController {
     }
 
     @Operation(summary = "인터페이스 정보 삭제", description = "인터페이스 정보를 삭제합니다. (회원탈퇴) ")
-    @RequestMapping(value = "/itf/deleteInterfaceInfo.do", method = RequestMethod.DELETE)
-    public ResponseEntity<?> deleteInterfaceInfo(
-            @Valid @ModelAttribute("interfaceVO") InterfaceAPIVO interfaceVO,
-            BindingResult bindingResult,
-            Model model,
-            SessionStatus status) throws Exception {
+    @DeleteMapping("/itf/deleteInterfaceInfo.do")
+    public ResponseEntity<Map<String, Object>> deleteInterfaceInfo(
+            @Valid InterfaceAPIVO interfaceVO,
+            BindingResult bindingResult) {
         Map<String, Object> response = new HashMap<>();
         if (bindingResult.hasErrors()) {
             return ResponseEntity.ok(validationErrorResponse(bindingResult));

--- a/device-api-web/src/main/resources/egovframework/hyb/mapper/mbl/itf/EgovInterfaceAPIGuide_SQL_altibase.xml
+++ b/device-api-web/src/main/resources/egovframework/hyb/mapper/mbl/itf/EgovInterfaceAPIGuide_SQL_altibase.xml
@@ -6,25 +6,62 @@
 	<resultMap id="interfaceInfo" type="egovframework.hyb.mbl.itf.service.InterfaceAPIVO">
 		<result property="sn" column="SN"/>
 		<result property="uuid" column="UUID"/>
+		<result property="emails" column="EMAILS"/>
+		<result property="userId" column="USER_ID"/>
+		<result property="userPw" column="USER_PW"/>
 	</resultMap>
 
 	<insert id="insertInterfaceInfo">
 		<selectKey keyProperty="sn" resultType="int" order="BEFORE">
-		   SELECT (IFNULL(MAX(SN), 0)+1) sn from INTERFACE WHERE UUID = #{uuid}
+		   SELECT (IFNULL(MAX(SN), 0)+1) sn from INTERFACE_EGOV WHERE UUID = #{uuid}		   
 		</selectKey>
 		
-		INSERT INTO INTERFACE 
-			( SN
-			  , UUID )
-		VALUES ( #{sn}
-			  , #{uuid})
+			INSERT INTO INTERFACE_EGOV 
+				( SN
+				  , UUID
+				  , EMAILS
+				  , USER_ID 
+				  , USER_PW)
+			VALUES ( #{sn}
+				  , #{uuid}
+				  , #{emails}
+				  , #{userId}
+				  , #{userPw})
+		
 	</insert>
 	
+	<delete id="deleteInterfaceInfo">
+		
+			DELETE FROM INTERFACE_EGOV
+			WHERE USER_ID = #{userId}
+			AND USER_PW = #{userPw}
+		
+	</delete>
+	
+	<select id="selectInterfaceInfo" resultMap="interfaceInfo">
+		
+			SELECT
+				SN, UUID, EMAILS, 
+				USER_ID, USER_PW
+			FROM INTERFACE_EGOV 
+			WHERE USER_ID = #{userId} 
+			AND USER_PW = #{userPw}
+		
+	</select>
+
 	<select id="selectInterfaceInfoList" parameterType="egovframework.hyb.mbl.itf.service.InterfaceAPIVO" resultMap="interfaceInfo">
 		SELECT
-			SN, UUID, USEYN
-		FROM INTERFACE
+			SN, UUID, EMAILS, 
+				USER_ID, USER_PW
+		FROM INTERFACE_EGOV
+		WHERE USER_ID = #{userId}
 		ORDER BY SN DESC
+	</select>
+
+	<select id="selectInterfaceInfoListTotCnt" parameterType="egovframework.hyb.mbl.itf.service.InterfaceAPIVO" resultType="int">
+			SELECT COUNT(*)
+			FROM INTERFACE_EGOV
+			WHERE USER_ID = #{userId}
 	</select>
 
 </mapper>

--- a/device-api-web/src/main/resources/egovframework/hyb/mapper/mbl/itf/EgovInterfaceAPIGuide_SQL_cubrid.xml
+++ b/device-api-web/src/main/resources/egovframework/hyb/mapper/mbl/itf/EgovInterfaceAPIGuide_SQL_cubrid.xml
@@ -6,24 +6,62 @@
 	<resultMap id="interfaceInfo" type="egovframework.hyb.mbl.itf.service.InterfaceAPIVO">
 		<result property="sn" column="SN"/>
 		<result property="uuid" column="UUID"/>
+		<result property="emails" column="EMAILS"/>
+		<result property="userId" column="USER_ID"/>
+		<result property="userPw" column="USER_PW"/>
 	</resultMap>
 
 	<insert id="insertInterfaceInfo">
 		<selectKey keyProperty="sn" resultType="int" order="BEFORE">
-		   SELECT (IFNULL(MAX(SN), 0)+1) sn from INTERFACE WHERE UUID = #{uuid}
+		   SELECT (IFNULL(MAX(SN), 0)+1) sn from INTERFACE_EGOV WHERE UUID = #{uuid}		   
 		</selectKey>
 		
-		INSERT INTO INTERFACE 
-			( SN
-			  , UUID )
-		VALUES ( #{sn}
-			  , #{uuid} )
+			INSERT INTO INTERFACE_EGOV 
+				( SN
+				  , UUID
+				  , EMAILS
+				  , USER_ID 
+				  , USER_PW)
+			VALUES ( #{sn}
+				  , #{uuid}
+				  , #{emails}
+				  , #{userId}
+				  , #{userPw})
+		
 	</insert>
 	
+	<delete id="deleteInterfaceInfo">
+		
+			DELETE FROM INTERFACE_EGOV
+			WHERE USER_ID = #{userId}
+			AND USER_PW = #{userPw}
+		
+	</delete>
+	
+	<select id="selectInterfaceInfo" resultMap="interfaceInfo">
+		
+			SELECT
+				SN, UUID, EMAILS, 
+				USER_ID, USER_PW
+			FROM INTERFACE_EGOV 
+			WHERE USER_ID = #{userId} 
+			AND USER_PW = #{userPw}
+		
+	</select>
+
 	<select id="selectInterfaceInfoList" parameterType="egovframework.hyb.mbl.itf.service.InterfaceAPIVO" resultMap="interfaceInfo">
-		SELECT SN, UUID
-		FROM INTERFACE
+		SELECT
+			SN, UUID, EMAILS, 
+				USER_ID, USER_PW
+		FROM INTERFACE_EGOV
+		WHERE USER_ID = #{userId}
 		ORDER BY SN DESC
+	</select>
+
+	<select id="selectInterfaceInfoListTotCnt" parameterType="egovframework.hyb.mbl.itf.service.InterfaceAPIVO" resultType="int">
+			SELECT COUNT(*)
+			FROM INTERFACE_EGOV
+			WHERE USER_ID = #{userId}
 	</select>
 
 </mapper>

--- a/device-api-web/src/main/resources/egovframework/hyb/mapper/mbl/itf/EgovInterfaceAPIGuide_SQL_mysql.xml
+++ b/device-api-web/src/main/resources/egovframework/hyb/mapper/mbl/itf/EgovInterfaceAPIGuide_SQL_mysql.xml
@@ -49,6 +49,15 @@
 		
 	</select>
 
+	<select id="selectInterfaceInfoList" parameterType="egovframework.hyb.mbl.itf.service.InterfaceAPIVO" resultMap="interfaceInfo">
+		SELECT
+			SN, UUID, EMAILS, 
+				USER_ID, USER_PW
+		FROM INTERFACE_EGOV
+		WHERE USER_ID = #{userId}
+		ORDER BY SN DESC
+	</select>
+
 	<select id="selectInterfaceInfoListTotCnt" parameterType="egovframework.hyb.mbl.itf.service.InterfaceAPIVO" resultType="int">
 			SELECT COUNT(*)
 			FROM INTERFACE_EGOV

--- a/device-api-web/src/main/resources/egovframework/hyb/mapper/mbl/itf/EgovInterfaceAPIGuide_SQL_oracle.xml
+++ b/device-api-web/src/main/resources/egovframework/hyb/mapper/mbl/itf/EgovInterfaceAPIGuide_SQL_oracle.xml
@@ -6,25 +6,62 @@
 	<resultMap id="interfaceInfo" type="egovframework.hyb.mbl.itf.service.InterfaceAPIVO">
 		<result property="sn" column="SN"/>
 		<result property="uuid" column="UUID"/>
+		<result property="emails" column="EMAILS"/>
+		<result property="userId" column="USER_ID"/>
+		<result property="userPw" column="USER_PW"/>
 	</resultMap>
 
 	<insert id="insertInterfaceInfo">
 		<selectKey keyProperty="sn" resultType="int" order="BEFORE">
-		   SELECT (IFNULL(MAX(SN), 0)+1) sn from INTERFACE WHERE UUID = #{uuid}
+		   SELECT (IFNULL(MAX(SN), 0)+1) sn from INTERFACE_EGOV WHERE UUID = #{uuid}		   
 		</selectKey>
 		
-		INSERT INTO INTERFACE 
-			( SN
-			  , UUID )
- 		VALUES ( #{sn}
-			  , #{uuid} )
+			INSERT INTO INTERFACE_EGOV 
+				( SN
+				  , UUID
+				  , EMAILS
+				  , USER_ID 
+				  , USER_PW)
+			VALUES ( #{sn}
+				  , #{uuid}
+				  , #{emails}
+				  , #{userId}
+				  , #{userPw})
+		
 	</insert>
 	
+	<delete id="deleteInterfaceInfo">
+		
+			DELETE FROM INTERFACE_EGOV
+			WHERE USER_ID = #{userId}
+			AND USER_PW = #{userPw}
+		
+	</delete>
+	
+	<select id="selectInterfaceInfo" resultMap="interfaceInfo">
+		
+			SELECT
+				SN, UUID, EMAILS, 
+				USER_ID, USER_PW
+			FROM INTERFACE_EGOV 
+			WHERE USER_ID = #{userId} 
+			AND USER_PW = #{userPw}
+		
+	</select>
+
 	<select id="selectInterfaceInfoList" parameterType="egovframework.hyb.mbl.itf.service.InterfaceAPIVO" resultMap="interfaceInfo">
 		SELECT
-			SN, UUID
-		FROM INTERFACE
+			SN, UUID, EMAILS, 
+				USER_ID, USER_PW
+		FROM INTERFACE_EGOV
+		WHERE USER_ID = #{userId}
 		ORDER BY SN DESC
+	</select>
+
+	<select id="selectInterfaceInfoListTotCnt" parameterType="egovframework.hyb.mbl.itf.service.InterfaceAPIVO" resultType="int">
+			SELECT COUNT(*)
+			FROM INTERFACE_EGOV
+			WHERE USER_ID = #{userId}
 	</select>
 
 </mapper>

--- a/device-api-web/src/main/resources/egovframework/hyb/mapper/mbl/itf/EgovInterfaceAPIGuide_SQL_tibero.xml
+++ b/device-api-web/src/main/resources/egovframework/hyb/mapper/mbl/itf/EgovInterfaceAPIGuide_SQL_tibero.xml
@@ -6,25 +6,62 @@
 	<resultMap id="interfaceInfo" type="egovframework.hyb.mbl.itf.service.InterfaceAPIVO">
 		<result property="sn" column="SN"/>
 		<result property="uuid" column="UUID"/>
+		<result property="emails" column="EMAILS"/>
+		<result property="userId" column="USER_ID"/>
+		<result property="userPw" column="USER_PW"/>
 	</resultMap>
 
 	<insert id="insertInterfaceInfo">
 		<selectKey keyProperty="sn" resultType="int" order="BEFORE">
-		   SELECT (IFNULL(MAX(SN), 0)+1) sn from INTERFACE WHERE UUID = #{uuid}
+		   SELECT (IFNULL(MAX(SN), 0)+1) sn from INTERFACE_EGOV WHERE UUID = #{uuid}		   
 		</selectKey>
 		
-		INSERT INTO INTERFACE 
-			( SN
-			  , UUID )
-		VALUES ( #{sn}
-			  , #{uuid} )
+			INSERT INTO INTERFACE_EGOV 
+				( SN
+				  , UUID
+				  , EMAILS
+				  , USER_ID 
+				  , USER_PW)
+			VALUES ( #{sn}
+				  , #{uuid}
+				  , #{emails}
+				  , #{userId}
+				  , #{userPw})
+		
 	</insert>
 	
+	<delete id="deleteInterfaceInfo">
+		
+			DELETE FROM INTERFACE_EGOV
+			WHERE USER_ID = #{userId}
+			AND USER_PW = #{userPw}
+		
+	</delete>
+	
+	<select id="selectInterfaceInfo" resultMap="interfaceInfo">
+		
+			SELECT
+				SN, UUID, EMAILS, 
+				USER_ID, USER_PW
+			FROM INTERFACE_EGOV 
+			WHERE USER_ID = #{userId} 
+			AND USER_PW = #{userPw}
+		
+	</select>
+
 	<select id="selectInterfaceInfoList" parameterType="egovframework.hyb.mbl.itf.service.InterfaceAPIVO" resultMap="interfaceInfo">
 		SELECT
-			SN, UUID
-		FROM INTERFACE
+			SN, UUID, EMAILS, 
+				USER_ID, USER_PW
+		FROM INTERFACE_EGOV
+		WHERE USER_ID = #{userId}
 		ORDER BY SN DESC
+	</select>
+
+	<select id="selectInterfaceInfoListTotCnt" parameterType="egovframework.hyb.mbl.itf.service.InterfaceAPIVO" resultType="int">
+			SELECT COUNT(*)
+			FROM INTERFACE_EGOV
+			WHERE USER_ID = #{userId}
 	</select>
 
 </mapper>


### PR DESCRIPTION
## 개요

인터페이스 API가 `INTERFACE_EGOV` 테이블의 사용자 계정 정보를 기준으로 데이터를 처리하도록 API 계층과 DB 매핑을 개선합니다.

## 주요 변경 사항

- 인터페이스 API 컨트롤러에 `@GetMapping`, `@PostMapping`, `@DeleteMapping`을 적용했습니다.
- 단건 조회 API의 HTTP 메서드를 POST에서 GET으로 변경했습니다.
- `ResponseEntity<Map<String, Object>>`와 `List<InterfaceAPIVO>`를 적용해 반환 타입을 구체화했습니다.
- 서비스와 DAO에서 불필요한 `throws Exception` 선언과 명시적 형 변환을 제거했습니다.
- Lombok 기반 생성자 주입과 디버그 로깅을 적용했습니다.
- 사용자 ID와 비밀번호를 기준으로 등록·조회·삭제할 수 있도록 SQL을 보강했습니다.
- 사용자 ID별 목록 조회 및 전체 건수 조회 쿼리를 추가했습니다.
- Altibase, CUBRID, MySQL, Oracle, Tibero 매퍼에 변경 사항을 반영했습니다.

## 영향 범위

- 인터페이스 정보 등록·로그인·단건 조회·목록 조회·삭제 API
- `INTERFACE_EGOV` 테이블을 사용하는 DB별 MyBatis 매퍼
- 인터페이스 API 서비스 및 DAO 반환 타입

## 테스트

- [ ] 자동화 테스트 미실행
- [x] DB별 인터페이스 정보 등록 및 로그인 확인
- [x] 사용자별 단건·목록·건수 조회 확인
- [x] 회원 탈퇴 요청 시 계정 정보 삭제 확인

http://localhost:9700/swagger-ui/index.html#/08.%20Interface%20Guide%20Program%20Service

## 제외 사항

- `EgovConfigMapper` 변경은 이번 PR에 포함하지 않습니다.

https://youtu.be/-aHxowe1rUs
