### PR TITLE
refactor(media): 미디어 API의 타입 안정성과 의존성 주입 개선

### DIFF
--- a/device-api-web/src/main/java/egovframework/hyb/mbl/mda/service/EgovMediaAPIService.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/mda/service/EgovMediaAPIService.java
@@ -7,15 +7,15 @@ import java.util.List;
  */
 public interface EgovMediaAPIService {
 
-    int insertMediaInfo(MediaAPIVO vo) throws Exception;
+    int insertMediaInfo(MediaAPIVO vo);
 
-    int updateMediaInfo(MediaAPIVO vo) throws Exception;
+    int updateMediaInfo(MediaAPIVO vo);
 
-    int deleteMediaInfo(MediaAPIVO vo) throws Exception;
+    int deleteMediaInfo(MediaAPIVO vo);
 
-    MediaAPIVO selectMediaInfo(MediaAPIVO vo) throws Exception;
+    MediaAPIVO selectMediaInfo(MediaAPIVO vo);
 
-    List<?> selectMediaInfoList(MediaAPIVO searchVO) throws Exception;
+    List<MediaAPIVO> selectMediaInfoList(MediaAPIVO searchVO);
 
-    int selectMediaInfoListTotCnt(MediaAPIVO searchVO) throws Exception;
+    int selectMediaInfoListTotCnt(MediaAPIVO searchVO);
 }

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/mda/service/impl/EgovMediaAPIServiceImpl.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/mda/service/impl/EgovMediaAPIServiceImpl.java
@@ -7,38 +7,41 @@ import org.springframework.stereotype.Service;
 
 import egovframework.hyb.mbl.mda.service.EgovMediaAPIService;
 import egovframework.hyb.mbl.mda.service.MediaAPIVO;
-import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 통합 Media API ServiceImpl
  */
-@Service("EgovMediaAPIService")
+@Service
+@RequiredArgsConstructor
+@Slf4j
 public class EgovMediaAPIServiceImpl extends EgovAbstractServiceImpl implements EgovMediaAPIService {
 
-    @Resource(name="MediaAPIDAO")
-    private MediaAPIDAO mediaAPIDAO;
+    private final MediaAPIDAO mediaAPIDAO;
 
-    public int insertMediaInfo(MediaAPIVO vo) throws Exception {
-        return (Integer) mediaAPIDAO.insertMediaInfo(vo);
+    public int insertMediaInfo(MediaAPIVO vo) {
+        return mediaAPIDAO.insertMediaInfo(vo);
     }
 
-    public int updateMediaInfo(MediaAPIVO vo) throws Exception {
-        return (Integer) mediaAPIDAO.updateMediaInfo(vo);
+    public int updateMediaInfo(MediaAPIVO vo) {
+        return mediaAPIDAO.updateMediaInfo(vo);
     }
 
-    public int deleteMediaInfo(MediaAPIVO vo) throws Exception {
-        return (Integer) mediaAPIDAO.deleteMediaInfo(vo);
+    public int deleteMediaInfo(MediaAPIVO vo) {
+        return mediaAPIDAO.deleteMediaInfo(vo);
     }
 
-    public MediaAPIVO selectMediaInfo(MediaAPIVO vo) throws Exception {
-        return (MediaAPIVO) mediaAPIDAO.selectMediaInfo(vo);
+    public MediaAPIVO selectMediaInfo(MediaAPIVO vo) {
+        return mediaAPIDAO.selectMediaInfo(vo);
     }
 
-    public List<?> selectMediaInfoList(MediaAPIVO searchVO) throws Exception {
+    public List<MediaAPIVO> selectMediaInfoList(MediaAPIVO searchVO) {
+        log.debug("uuid={}", searchVO.getUuid());
         return mediaAPIDAO.selectMediaInfoList(searchVO);
     }
 
-    public int selectMediaInfoListTotCnt(MediaAPIVO searchVO) throws Exception {
-        return (Integer) mediaAPIDAO.selectMediaInfoListTotCnt(searchVO);
+    public int selectMediaInfoListTotCnt(MediaAPIVO searchVO) {
+        return mediaAPIDAO.selectMediaInfoListTotCnt(searchVO);
     }
 }

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/mda/service/impl/MediaAPIDAO.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/mda/service/impl/MediaAPIDAO.java
@@ -10,30 +10,30 @@ import egovframework.hyb.mbl.mda.service.MediaAPIVO;
 /**
  * 통합 Media API DAO
  */
-@Repository("MediaAPIDAO")
+@Repository
 public class MediaAPIDAO extends EgovAbstractMapper {
 
     public int insertMediaInfo(MediaAPIVO vo) {
-        return (Integer) insert("mediaAPIDAO.insertMediaInfo", vo);
+        return insert("mediaAPIDAO.insertMediaInfo", vo);
     }
 
     public int updateMediaInfo(MediaAPIVO vo) {
-        return (Integer) update("mediaAPIDAO.updateMediaInfo", vo);
+        return update("mediaAPIDAO.updateMediaInfo", vo);
     }
 
     public int deleteMediaInfo(MediaAPIVO vo) {
-        return (Integer) delete("mediaAPIDAO.deleteMediaInfo", vo);
+        return delete("mediaAPIDAO.deleteMediaInfo", vo);
     }
 
     public MediaAPIVO selectMediaInfo(MediaAPIVO vo) {
-        return (MediaAPIVO) selectOne("mediaAPIDAO.selectMediaInfo", vo);
+        return selectOne("mediaAPIDAO.selectMediaInfo", vo);
     }
 
-    public List<?> selectMediaInfoList(MediaAPIVO searchVO) {
+    public List<MediaAPIVO> selectMediaInfoList(MediaAPIVO searchVO) {
         return selectList("mediaAPIDAO.selectMediaInfoList", searchVO);
     }
 
     public int selectMediaInfoListTotCnt(MediaAPIVO searchVO) {
-        return (Integer) selectOne("mediaAPIDAO.selectMediaInfoListTotCnt", searchVO);
+        return selectOne("mediaAPIDAO.selectMediaInfoListTotCnt", searchVO);
     }
 }

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/mda/web/EgovMediaAPIController.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/mda/web/EgovMediaAPIController.java
@@ -10,20 +10,26 @@ import java.util.Map;
 import org.egovframe.rte.fdl.property.EgovPropertyService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.ui.ModelMap;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.support.SessionStatus;
 import org.springframework.web.multipart.MultipartFile;
 
 import egovframework.hyb.mbl.mda.service.EgovMediaAPIService;
 import egovframework.hyb.mbl.mda.service.MediaAPIVO;
+import egovframework.hyb.mbl.mda.service.impl.EgovMediaAPIServiceImpl;
 import egovframework.hyb.utils.EgovFileMngUtil;
 import egovframework.hyb.utils.EgovFileService;
 import egovframework.hyb.utils.FileVO;
@@ -33,18 +39,19 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 통합 Media API Controller
  */
 @Controller
+@RequiredArgsConstructor
+@Slf4j
 @Tag(name = "09. Media Guide Program Service", description = "미디어 API 관리")
 public class EgovMediaAPIController {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(EgovMediaAPIController.class);
-
-    @Resource(name = "EgovMediaAPIService")
-    private EgovMediaAPIService egovMediaAPIService;
+    private final EgovMediaAPIService egovMediaAPIService;
     
     @Resource(name = "EgovFileService")
     private EgovFileService egovFileService;
@@ -52,24 +59,22 @@ public class EgovMediaAPIController {
     @Resource(name = "egovFileMngUtil")
     private EgovFileMngUtil fileMngUtil;
 
-    @Resource(name = "propertiesService")
-    protected EgovPropertyService propertiesService;
-
     @Operation(summary = "미디어 정보 목록 조회", description = "미디어 정보 목록을 조회합니다.")
-    @RequestMapping(value = "/mda/selectMediaInfoList.do", method = RequestMethod.GET)
-    public ResponseEntity<?> selectMediaInfoList(@ModelAttribute("searchVO") MediaAPIVO searchVO, ModelMap model) throws Exception {
+    @GetMapping("/mda/selectMediaInfoList.do")
+    public ResponseEntity<Map<String, Object>> selectMediaInfoList(MediaAPIVO searchVO) {
+        log.debug("uuid={}", searchVO.getUuid());
         Map<String, Object> response = new HashMap<>();
-        List<?> mediaInfoList = egovMediaAPIService.selectMediaInfoList(searchVO);
+        List<MediaAPIVO> mediaInfoList = egovMediaAPIService.selectMediaInfoList(searchVO);
         //List<?> mediaInfoList = egovMediaAPIService.selectMediaInfoList(searchVO);
         response.put("mediaInfoList", mediaInfoList);
-        LOGGER.debug("Media info list retrieved: {} items", mediaInfoList != null ? mediaInfoList.size() : 0);
+        log.debug("Media info list retrieved: {} items", mediaInfoList != null ? mediaInfoList.size() : 0);
         response.put("resultState", "OK");
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "미디어 정보 등록", description = "미디어 정보를 등록합니다.")
-    @RequestMapping(value = "/mda/insertMediaInfo.do", method = RequestMethod.POST)
-    public ResponseEntity<?> insertMediaInfo(MediaAPIVO mediaVO, BindingResult bindingResult, Model model, SessionStatus status) throws Exception {
+    @PostMapping("/mda/insertMediaInfo.do")
+    public ResponseEntity<Map<String, Object>> insertMediaInfo(MediaAPIVO mediaVO) {
         Map<String, Object> response = new HashMap<>();
         mediaVO.setMdCode("MLT03");
         mediaVO.setUseyn("Y");
@@ -86,8 +91,8 @@ public class EgovMediaAPIController {
     }
 
     @Operation(summary = "미디어 정보 삭제", description = "미디어 정보를 삭제합니다.")
-    @RequestMapping(value = "/mda/deleteMediaInfo.do", method = RequestMethod.DELETE)
-    public ResponseEntity<?> deleteMediaInfo(MediaAPIVO mediaVO, BindingResult bindingResult, Model model, SessionStatus status) throws Exception {
+    @DeleteMapping("/mda/deleteMediaInfo.do")
+    public ResponseEntity<Map<String, Object>> deleteMediaInfo(MediaAPIVO mediaVO) {
         Map<String, Object> response = new HashMap<>();
         int cnt = egovMediaAPIService.deleteMediaInfo(mediaVO);
         if(cnt > 0) {
@@ -101,12 +106,11 @@ public class EgovMediaAPIController {
     }
 
     @Operation(summary = "미디어 파일 업로드", description = "미디어 파일을 업로드합니다. (단일 또는 여러 파일 지원)")
-    @RequestMapping(value = "/mda/uploadMediaFile.do", method = RequestMethod.POST)
-    public ResponseEntity<?> uploadMediaFile(
-            @Parameter(description = "업로드할 파일(들)") @RequestParam("files") MultipartFile[] files,
-            @Parameter(description = "기기 식별코드") @RequestParam("uuid") String uuid,
-            @Parameter(description = "시작 SN") @RequestParam(value = "startSn", required = false, defaultValue = "1") int startSn,
-            HttpServletRequest request) throws Exception {
+    @PostMapping(value = "/mda/uploadMediaFile.do", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Map<String, Object>> uploadMediaFile(
+            @Parameter(description = "업로드할 파일(들)") @RequestPart MultipartFile[] files,
+            @Parameter(description = "기기 식별코드") @RequestParam String uuid,
+            @Parameter(description = "시작 SN") @RequestParam(required = false, defaultValue = "1") int startSn) {
        
         Map<String, Object> response = new HashMap<>();
         
@@ -203,10 +207,10 @@ public class EgovMediaAPIController {
     }
 
     @Operation(summary = "미디어 파일 다운로드", description = "기기 UUID 소유권을 검증한 뒤 미디어 파일을 다운로드합니다.")
-    @RequestMapping(value = "/mda/downloadMediaFile.do", method = RequestMethod.GET)
+    @GetMapping("/mda/downloadMediaFile.do")
     public void downloadMediaFile(
-            @Parameter(description = "파일 일련번호") @RequestParam("fileSn") int fileSn,
-            @Parameter(description = "기기 식별코드") @RequestParam("uuid") String uuid,
+            @Parameter(description = "파일 일련번호") @RequestParam int fileSn,
+            @Parameter(description = "기기 식별코드") @RequestParam String uuid,
             HttpServletResponse response) throws Exception {
         try {
         	byte[] fileData = fileMngUtil.fileDownload(response, fileSn, uuid);


### PR DESCRIPTION
## 변경 사항

- 미디어 API 서비스 메서드에서 불필요한 `throws Exception` 선언을 제거했습니다.
- 미디어 목록 반환 타입을 `List<?>`에서 `List<MediaAPIVO>`로 구체화했습니다.
- 서비스와 DAO에서 불필요한 명시적 형변환을 제거했습니다.
- 미디어 서비스와 컨트롤러에 생성자 기반 의존성 주입을 적용했습니다.
- Lombok `@Slf4j`를 적용해 로깅 방식을 일관되게 정리했습니다.
- 컨트롤러의 범용 `@RequestMapping`을 `@GetMapping`, `@PostMapping`, `@DeleteMapping`으로 구체화했습니다.
- API 응답 타입을 `ResponseEntity<Map<String, Object>>`로 명확히 했습니다.
- 미디어 파일 업로드 API의 multipart 요청 형식과 파일 파라미터 바인딩을 명시했습니다.
- 사용하지 않는 컨트롤러 파라미터와 의존성을 제거했습니다.

## 변경 범위

- `EgovMediaAPIService`
- `EgovMediaAPIServiceImpl`
- `MediaAPIDAO`
- `EgovMediaAPIController`

## 테스트

- 별도 테스트는 수행하지 않았습니다.
- 미디어 목록 조회, 등록, 삭제, 파일 업로드 및 다운로드 API에 대한 회귀 확인이 필요합니다.

## 참고

- `EgovConfigMapper` 변경은 이 PR 범위에서 제외합니다.
- Breaking Change는 없습니다.

http://localhost:9700/swagger-ui/index.html#/09.%20Media%20Guide%20Program%20Service

https://youtu.be/HymrN1xwNeU
