### PR TITLE
refactor(file-opener): API 타입 안정성과 의존성 주입 방식을 개선

### DIFF
--- a/device-api-web/src/main/java/egovframework/hyb/mbl/fop/service/EgovFileOpenerDeviceAPIService.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/fop/service/EgovFileOpenerDeviceAPIService.java
@@ -40,8 +40,7 @@ public interface EgovFileOpenerDeviceAPIService {
 	 * Push Device 정보 목록을 조회한다.
 	 * @param VO - 조회할 정보가 담긴 PushDeviceAPIDefaultVO
 	 * @return 네트워크 정보 목록
-	 * @exception Exception
 	 */
-	List<?> selectFileOpenerList(FileOpenerDeviceAPIVO searchVO) throws Exception;
+	List<FileOpenerDeviceAPIVO> selectFileOpenerList(FileOpenerDeviceAPIVO searchVO);
 	
 }

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/fop/service/impl/EgovFileOpenerDeviceAPIServiceImpl.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/fop/service/impl/EgovFileOpenerDeviceAPIServiceImpl.java
@@ -18,13 +18,12 @@ package egovframework.hyb.mbl.fop.service.impl;
 import java.util.List;
 
 import org.egovframe.rte.fdl.cmmn.EgovAbstractServiceImpl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import egovframework.hyb.mbl.fop.service.EgovFileOpenerDeviceAPIService;
 import egovframework.hyb.mbl.fop.service.FileOpenerDeviceAPIVO;
-import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 
 /**  
@@ -45,23 +44,21 @@ import jakarta.annotation.Resource;
  *  Copyright (C) by Ministry of Interior All right reserved.
  */
 
-@Service("EgovFileOpenerDeviceAPIService")
+@Service
+@RequiredArgsConstructor
+@Slf4j
 public class EgovFileOpenerDeviceAPIServiceImpl extends EgovAbstractServiceImpl implements EgovFileOpenerDeviceAPIService {
 	
-	private static final Logger LOGGER = LoggerFactory.getLogger(EgovFileOpenerDeviceAPIServiceImpl.class);
-
 	/** FileOpenerDeviceAPIDAO */
-    @Resource(name="FileOpenerDeviceAPIDAO")
-    private FileOpenerDeviceAPIDAO fileOpenerDeviceAPIDAO;
+    private final FileOpenerDeviceAPIDAO fileOpenerDeviceAPIDAO;
 
     /**
 	 * 문서목록을 조회한다.
 	 * @param VO - 조회할 정보가 담긴 FileOpenerDeviceAPIVO
 	 * @return 문서 조회 목록 
-	 * @exception Exception
 	 */
-    public List<?> selectFileOpenerList(FileOpenerDeviceAPIVO searchVO) throws Exception {
-		// TODO Auto-generated method stub
+    public List<FileOpenerDeviceAPIVO> selectFileOpenerList(FileOpenerDeviceAPIVO searchVO) {
+		log.debug("uuid={}", searchVO.getUuid());
 		return fileOpenerDeviceAPIDAO.selectFileOpenerList(searchVO);
 	}
     

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/fop/service/impl/FileOpenerDeviceAPIDAO.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/fop/service/impl/FileOpenerDeviceAPIDAO.java
@@ -41,7 +41,7 @@ import egovframework.hyb.mbl.fop.service.FileOpenerDeviceAPIVO;
  *  Copyright (C) by Ministry of Interior All right reserved.
  */
 
-@Repository("FileOpenerDeviceAPIDAO")
+@Repository
 public class FileOpenerDeviceAPIDAO extends EgovAbstractMapper {
 
     /**
@@ -49,7 +49,7 @@ public class FileOpenerDeviceAPIDAO extends EgovAbstractMapper {
 	 * @param vo - 조회할 정보가 담긴 PushDeviceAPIDefaultVO
 	 * @return Push Device 정보 목록
 	 */
-    public List<?> selectFileOpenerList(FileOpenerDeviceAPIVO searchVO) {
+    public List<FileOpenerDeviceAPIVO> selectFileOpenerList(FileOpenerDeviceAPIVO searchVO) {
         return selectList("fileOpenerDeviceAPIDAO.selectDocumentListInfo", searchVO);
     }
 

--- a/device-api-web/src/main/java/egovframework/hyb/mbl/fop/web/EgovFileOpenerDeviceAPIController.java
+++ b/device-api-web/src/main/java/egovframework/hyb/mbl/fop/web/EgovFileOpenerDeviceAPIController.java
@@ -5,14 +5,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.ModelMap;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import egovframework.hyb.mbl.fop.service.EgovFileOpenerDeviceAPIService;
@@ -22,31 +17,31 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 통합 File Opener API Controller
  */
 @Controller
+@RequiredArgsConstructor
+@Slf4j
 @Tag(name = "13. FileOpener Guide Program Service", description = "파일 오프너 API 관리")
 public class EgovFileOpenerDeviceAPIController {
 
-	private final Logger log = LoggerFactory.getLogger(EgovFileOpenerDeviceAPIController.class);
-
-    @Resource(name = "EgovFileOpenerDeviceAPIService")
-    private EgovFileOpenerDeviceAPIService egovFileOpenerDeviceAPIService;
+    private final EgovFileOpenerDeviceAPIService egovFileOpenerDeviceAPIService;
 
 	@Resource(name = "egovFileMngUtil")
 	private EgovFileMngUtil egovFileMngUtil;
 
 	@Operation(summary = "파일 오프너 정보 목록 조회", description = "기기 UUID에 해당하는 파일 오프너 정보 목록을 조회합니다.")
-    @RequestMapping(value = "/fop/selectFileOpenerList.do", method = RequestMethod.GET)
-    public ResponseEntity<?> selectFileOpenerList(
-    		@Parameter(description = "기기 식별코드") @ModelAttribute("fileOpenerDviceAPIVO") FileOpenerDeviceAPIVO searchVO,
-    		ModelMap model) throws Exception {
+	@GetMapping("/fop/selectFileOpenerList.do")
+    public ResponseEntity<Map<String, Object>> selectFileOpenerList(
+    		@Parameter(description = "기기 식별코드") FileOpenerDeviceAPIVO searchVO) {
+		log.debug("uuid={}", searchVO.getUuid());
 		Map<String, Object> response = new HashMap<>();
-		List<?> fileOpenerDeviceAPIVO = egovFileOpenerDeviceAPIService.selectFileOpenerList(searchVO);
+		List<FileOpenerDeviceAPIVO> fileOpenerDeviceAPIVO = egovFileOpenerDeviceAPIService.selectFileOpenerList(searchVO);
 		response.put("resultSet", fileOpenerDeviceAPIVO);
 		response.put("resultState","OK");
 		return ResponseEntity.ok(response);
@@ -54,18 +49,16 @@ public class EgovFileOpenerDeviceAPIController {
 
 	/**
 	 * 선택된 파일을 클라이언트로 전송한다.
-	 * @param request -  HttpServletRequest 
 	 * @param response - HttpServletResponse 
 	 * @param fileVO - 전송할 파일 정보가 담긴 ResourceUpdateDeviceAPIVO 
 	 * @return ModelAndView
 	 * @exception Exception
 	 */
     @Operation(summary = "파일 오프너 파일 다운로드", description = "기기 UUID 소유권을 검증한 뒤 파일을 다운로드합니다.")
-    @RequestMapping(value = "/fop/fileDownload.do", method = RequestMethod.GET)
+    @GetMapping("/fop/fileDownload.do")
 	public void fileDownload(
-			@Parameter(description = "기기 식별코드") @RequestParam("uuid") String uuid,
-			@Parameter(description = "파일 일련번호") @RequestParam("fileSn") int fileSn,
-			HttpServletRequest request,
+			@Parameter(description = "기기 식별코드") @RequestParam String uuid,
+			@Parameter(description = "파일 일련번호") @RequestParam int fileSn,
 			HttpServletResponse response) throws Exception {
         try {
       	byte[] fildData = egovFileMngUtil.fileDownload(response, fileSn, uuid);


### PR DESCRIPTION
## 변경 사항

- File Opener 서비스와 DAO의 조회 반환 타입을 `List<FileOpenerDeviceAPIVO>`로 구체화
- 서비스와 컨트롤러의 의존성 주입 방식을 Lombok 기반 생성자 주입으로 변경
- `@Slf4j`를 적용하고 UUID 조회 로그 추가
- `@RequestMapping`을 `@GetMapping`으로 간소화
- 목록 조회 API의 응답 타입을 `ResponseEntity<Map<String, Object>>`로 구체화
- 파일 다운로드 API에서 사용하지 않는 `HttpServletRequest` 매개변수 제거
- 불필요한 `throws Exception`, 주석 및 import 정리
- DAO와 서비스의 명시적 빈 이름 제거

## 영향 범위

- File Opener 목록 조회 API
- File Opener 파일 다운로드 API
- File Opener 서비스 및 DAO 계층

## 테스트

- [ ] File Opener 목록 조회 API 정상 응답 확인
- [ ] UUID에 해당하는 문서 목록 조회 확인
- [ ] 정상 UUID와 파일 일련번호로 파일 다운로드 확인
- [ ] 유효하지 않은 UUID 또는 파일 일련번호 처리 확인

https://youtu.be/tbhCPsD9g0U
