### PR TITLE
파일 삭제 시 저장 확장자 누락으로 실제 파일이 삭제되지 않는 문제 수정

### DIFF
--- a/device-api-web/src/main/java/egovframework/hyb/utils/EgovFileMngUtil.java
+++ b/device-api-web/src/main/java/egovframework/hyb/utils/EgovFileMngUtil.java
@@ -258,7 +258,9 @@ public class EgovFileMngUtil extends EgovAbstractServiceImpl {
 	public void deleteFile(FileVO fileVO) throws Exception {
 
 		// 2022.11.11 시큐어코딩 처리 - 경로 검증 추가
-		String deleteFilePath = EgovWebUtil.filePathBlackList(filePath + File.separator + fileVO.getStreFileNm());
+		// 저장·다운로드와 동일하게 확장자를 포함해야 실제 저장 파일을 가리킨다.
+		String deleteFilePath = EgovWebUtil.filePathBlackList(
+				filePath + File.separator + fileVO.getStreFileNm() + "." + fileVO.getFileExtsn());
 		File file = new File(deleteFilePath);
 
 		if (!file.exists()) {

--- a/device-api-web/src/test/java/egovframework/hyb/utils/EgovFileMngUtilDeleteTest.java
+++ b/device-api-web/src/test/java/egovframework/hyb/utils/EgovFileMngUtilDeleteTest.java
@@ -1,0 +1,36 @@
+package egovframework.hyb.utils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EgovFileMngUtilDeleteTest {
+
+    @Test
+    void deleteFile_저장확장자를_포함해_실제파일을_삭제한다(@TempDir Path tempDir) throws Exception {
+        // 업로드 저장 로직은 streFileNm(확장자 없음) + "." + fileExtsn 으로 파일을 만든다.
+        String streFileNm = "File_20260809_1";
+        String fileExtsn = "jpg";
+        Path stored = tempDir.resolve(streFileNm + "." + fileExtsn);
+        Files.writeString(stored, "img");
+        assertThat(Files.exists(stored)).isTrue();
+
+        EgovFileMngUtil util = new EgovFileMngUtil();
+        util.filePath = tempDir.toString();
+
+        FileVO fileVO = new FileVO();
+        fileVO.setStreFileNm(streFileNm);
+        fileVO.setFileExtsn(fileExtsn);
+
+        util.deleteFile(fileVO);
+
+        // 수정 전에는 삭제 경로에 확장자를 붙이지 않아 실제 파일을 찾지 못하고 고아 파일로 남았다.
+        assertThat(Files.exists(stored))
+                .as("삭제는 저장·다운로드와 동일하게 확장자를 포함해 실제 파일을 제거해야 한다")
+                .isFalse();
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovFileMngUtil`의 업로드 저장·다운로드·삭제 경로가 파일명을 서로 다르게 구성합니다.

- **저장**: `streFileNm`(확장자 없음)을 저장하고, 실제 파일은 `streFileNm + "." + fileExtsn`으로 씁니다.
- **다운로드**(`fileDownload`): `getStreFileNm() + "." + getFileExtsn()` — 확장자 포함 ✅
- **삭제**(`deleteFile`): `getStreFileNm()` — **확장자 누락** ❌

```java
// 수정 전 (삭제)
String deleteFilePath = EgovWebUtil.filePathBlackList(filePath + File.separator + fileVO.getStreFileNm());
```

따라서 `File_20260809_1.jpg`로 저장된 파일을 삭제하려 할 때 대상 경로가 `File_20260809_1`(확장자 없음)이 되어 `file.exists()`가 false가 되고, `deleteFile`은 "There is no file to remove."를 로그로 남기며 **실제 파일을 지우지 않은 채 종료**합니다. 결과적으로 삭제 요청이 성공한 것처럼 보이지만 디스크에 **고아 파일이 계속 쌓입니다**.

**수정 내용**: 삭제 경로를 다운로드와 동일하게 확장자를 포함하도록 맞춥니다.

```java
// 수정 후
String deleteFilePath = EgovWebUtil.filePathBlackList(
        filePath + File.separator + fileVO.getStreFileNm() + "." + fileVO.getFileExtsn());
```

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests

`EgovFileMngUtilDeleteTest`를 추가했습니다. `@TempDir`에 `File_20260809_1.jpg`를 만들고, `streFileNm=File_20260809_1`·`fileExtsn=jpg`인 `FileVO`로 `deleteFile`을 호출한 뒤 실제 파일이 삭제되는지 검증합니다.

**실측 (JDK 21, `mvn test -Dtest=EgovFileMngUtilDeleteTest`)**

| 구분 | 결과 |
|---|---|
| 수정 전 | 테스트 **실패** — 확장자 없는 경로를 삭제 대상으로 삼아 실제 `.jpg` 파일이 고아로 잔존 |
| 수정 후 | 테스트 **통과** — 실제 파일 삭제 확인 |

패치 없이는 실패해 결함을 재현하고, 패치 적용 시 통과합니다(TDD).

## 테스트 브라우저 Test Browser

- [X] 기타 Others — 서버측 파일 처리 로직만 수정. UI 변경 없음.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

UI 변경이 없어 해당 없음. 위 JUnit 실측으로 대신합니다.