### PR TITLE
fix(file): 업로드 파일명 타임스탬프 24시간제(HH)로 수정 — 오전/오후 파일명 충돌 방지

### DIFF
--- a/device-api-web/src/main/java/egovframework/hyb/utils/EgovFileMngUtil.java
+++ b/device-api-web/src/main/java/egovframework/hyb/utils/EgovFileMngUtil.java
@@ -366,14 +366,26 @@ public class EgovFileMngUtil extends EgovAbstractServiceImpl {
 	 * @see
 	 */
 	private String getTimeStamp() {
+		return getTimeStamp(System.currentTimeMillis());
+	}
+
+	/**
+	 * 지정한 시각(epoch milliseconds)으로 TIMESTAMP 문자열을 구한다.
+	 * 24시간제(HH)를 사용해 오전(01시)과 오후(13시)가 같은 문자열로 겹치지 않도록 한다.
+	 * 테스트에서 시각을 주입할 수 있도록 분리했다.
+	 *
+	 * @param epochMillis 기준 시각(1970-01-01 UTC 이후 밀리초)
+	 * @return TIMESTAMP 값
+	 */
+	String getTimeStamp(long epochMillis) {
 
 		String rtnStr = null;
 
 		// 문자열로 변환하기 위한 패턴 설정(연도-월-일 시:분:초)
-		String pattern = "yyyyMMddhhmmss";
+		String pattern = "yyyyMMddHHmmss";
 
 		SimpleDateFormat sdfCurrent = new SimpleDateFormat(pattern, Locale.KOREA);
-		Timestamp ts = new Timestamp(System.currentTimeMillis());
+		Timestamp ts = new Timestamp(epochMillis);
 
 		rtnStr = sdfCurrent.format(ts.getTime());
 

--- a/device-api-web/src/test/java/egovframework/hyb/utils/EgovFileMngUtilTimeStampTest.java
+++ b/device-api-web/src/test/java/egovframework/hyb/utils/EgovFileMngUtilTimeStampTest.java
@@ -1,0 +1,41 @@
+package egovframework.hyb.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Calendar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 업로드 파일명에 쓰이는 타임스탬프가 24시간제로 생성되는지 검증한다.
+ *
+ * <p>수정 전에는 패턴이 12시간제({@code hh})라 13시가 "01"로 포맷돼 01시와 문자열이
+ * 겹쳤고, 같은 분·초에 오전/오후로 업로드된 파일이 동일한 이름을 얻어 덮어써졌다.
+ * ({@code File_<타임스탬프>_<키>} 형식, 키는 요청 단위로 1부터 증가)</p>
+ */
+class EgovFileMngUtilTimeStampTest {
+
+    @Test
+    void getTimeStamp_오후시각을_24시간제로_포맷해_오전과_겹치지_않는다() {
+        EgovFileMngUtil util = new EgovFileMngUtil();
+
+        // JVM 기본 시간대·SimpleDateFormat이 같은 기본 시간대를 쓰므로,
+        // Calendar로 만든 지역시각의 '시'와 포맷 결과의 '시'가 시간대와 무관하게 일치한다.
+        // (DST 경계를 피하려고 1월 날짜를 사용한다.)
+        String afternoonTs = util.getTimeStamp(localMillis(2026, Calendar.JANUARY, 2, 13, 4, 5));
+        String morningTs = util.getTimeStamp(localMillis(2026, Calendar.JANUARY, 2, 1, 4, 5));
+
+        assertThat(afternoonTs).isEqualTo("20260102130405");
+        assertThat(morningTs).isEqualTo("20260102010405");
+        assertThat(afternoonTs)
+                .as("오후(13시) 타임스탬프는 24시간제로 포맷돼 오전(01시)과 달라야 파일 덮어쓰기가 없다")
+                .isNotEqualTo(morningTs);
+    }
+
+    private static long localMillis(int year, int month, int day, int hour, int minute, int second) {
+        Calendar cal = Calendar.getInstance();
+        cal.clear();
+        cal.set(year, month, day, hour, minute, second);
+        return cal.getTimeInMillis();
+    }
+}


### PR DESCRIPTION
## 문제

업로드 파일 저장 시 파일명은 File_<타임스탬프>_<키> 형식으로 만들어지고, 타임스탬프는 EgovFileMngUtil.getTimeStamp() 가 생성합니다. 이 패턴이 "yyyyMMddhhmmss" 로 12시간제(hh)를 사용합니다.

hh 는 오전/오후를 구분하지 않으므로 13시가 "01" 로 포맷됩니다. 그 결과 같은 분·초에 오전 01시와 오후 13시로 업로드된 파일이 동일한 타임스탬프 문자열을 얻고, 요청 단위로 1부터 시작하는 키까지 같으면 같은 파일명(File_20260102010405_1)이 되어 먼저 저장된 파일이 덮어써집니다(데이터 유실).

## 수정

타임스탬프 패턴을 24시간제 "yyyyMMddHHmmss" 로 바꿔 오전/오후가 서로 다른 문자열이 되도록 했습니다. 또한 결정론적 테스트가 가능하도록 시각을 주입받는 getTimeStamp(long epochMillis) 오버로드로 분리하고, 인자 없는 기존 메서드는 이를 위임 호출하도록 했습니다(동작 동일).

## 검증

- EgovFileMngUtilTimeStampTest 회귀 테스트 추가: JVM 기본 시간대와 무관하게(Calendar로 지역시각 구성) 13시가 "20260102130405" 로 포맷돼 01시("20260102010405")와 겹치지 않음을 검증합니다.
- 독립 하네스 재현: hh 는 13:04:05 와 01:04:05 가 모두 "...010405" 로 충돌(동일), HH 는 서로 다름.
- 수정 전 테스트 실패 → 수정 후 통과(TDD 토글) 확인, Maven tests=1·failures=0·errors=0.

참고: 같은 초에 서로 다른 요청이 동시에 업로드되면 여전히 충돌 가능하나(초 단위 해상도 + 요청별 키 리셋), 이는 별도 설계 개선(밀리초·UUID 등) 사안으로 이 PR 범위 밖입니다.